### PR TITLE
docs: add per-crate READMEs and fix crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Matthew Downs <matthew@neer.ai>"]
 license = "AGPL-3.0-only"
 repository = "https://github.com/neeraip/hydra"
 homepage = "https://github.com/neeraip/hydra"
-documentation = "https://github.com/neeraip/hydra"
+documentation = "https://neeraip.github.io/hydra/"
 
 
 # Optimise the core library even in dev/test builds so that benchmark parity

--- a/README.md
+++ b/README.md
@@ -26,45 +26,7 @@ Download the installer for your platform from the [releases page](https://github
 
 ### CLI
 
-**Option 1 — Pre-built binary** (no Rust required)
-
-Download the `hydra` binary for your platform from the [releases page](https://github.com/neeraip/hydra/releases/latest).
-
-> **macOS** — After downloading, remove the quarantine flag before running:
-> ```sh
-> xattr -d com.apple.quarantine hydra
-> ```
-
-**Option 2 — Cargo**
-
-```sh
-cargo install hydra-cli
-```
-
-## Usage
-
-```sh
-# Run a simulation — report goes to stdout
-hydra network.inp
-
-# Write report and binary output to files
-hydra network.inp report.rpt output.out
-
-# Named flags (equivalent)
-hydra --input network.inp --report report.rpt --output output.out
-
-# Accept an HTTP URL as input
-hydra https://example.com/network.inp
-
-# JSON report
-hydra network.inp --report report.json
-
-# Suppress progress output
-hydra -q network.inp
-
-# Print version
-hydra -v
-```
+See [crates/cli/README.md](crates/cli/README.md) for install options and usage.
 
 ## Documentation
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 description = "CLI for Hydra — reads network descriptions from files, writes results to files"
+readme = "README.md"
+keywords = ["epanet", "water", "hydraulics", "simulation", "cli"]
+categories = ["science", "simulation", "command-line-utilities"]
 
 [[bin]]
 name = "hydra"

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,0 +1,64 @@
+# hydra-cli
+
+[![Crates.io](https://img.shields.io/crates/v/hydra-cli)](https://crates.io/crates/hydra-cli)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://github.com/neeraip/hydra/blob/main/LICENSE)
+[![Cargo CI](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml/badge.svg)](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml)
+
+Command-line interface for [Hydra](https://github.com/neeraip/hydra) — reads EPANET `.inp` network descriptions from files or HTTP URLs, runs extended-period hydraulic and water quality simulation, and writes results to `.rpt` and `.out` files.
+
+**[→ Full documentation](https://neeraip.github.io/hydra/getting-started/cli.html)**
+
+## Install
+
+**Option 1 — Pre-built binary** (no Rust required)
+
+Download the `hydra` binary for your platform from the [releases page](https://github.com/neeraip/hydra/releases/latest).
+
+> **macOS** — After downloading, remove the quarantine flag before running:
+> ```sh
+> xattr -d com.apple.quarantine hydra
+> ```
+
+**Option 2 — Cargo**
+
+```sh
+cargo install hydra-cli
+```
+
+## Usage
+
+```sh
+# Run a simulation — report goes to stdout
+hydra network.inp
+
+# Write report and binary output to files
+hydra network.inp report.rpt output.out
+
+# Named flags (equivalent)
+hydra --input network.inp --report report.rpt --output output.out
+
+# Accept an HTTP URL as input
+hydra https://example.com/network.inp
+
+# JSON report
+hydra network.inp --report report.json
+
+# Suppress progress output
+hydra -q network.inp
+
+# Print version
+hydra -v
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Simulation completed (warnings may appear in the report) |
+| `1` | Input validation error (bad INP, HTTP 4xx, missing file) |
+| `2` | Solver error (non-convergence or singularity) |
+| `3` | I/O error (file not found, permission denied, HTTP 5xx, network) |
+
+## License
+
+[AGPL v3](https://github.com/neeraip/hydra/blob/main/LICENSE) — see [COMMERCIAL_LICENSE.md](https://github.com/neeraip/hydra/blob/main/.github/COMMERCIAL_LICENSE.md) for commercial licensing options.

--- a/crates/engine-wds/Cargo.toml
+++ b/crates/engine-wds/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 description = "Hydra water distribution engine — data model, hydraulic solver, quality engine, session API, analytics"
+readme = "README.md"
+keywords = ["epanet", "water", "hydraulics", "simulation", "network"]
+categories = ["science", "simulation"]
 
 [features]
 test-support = []

--- a/crates/engine-wds/README.md
+++ b/crates/engine-wds/README.md
@@ -1,0 +1,28 @@
+# hydra-engine-wds
+
+[![Crates.io](https://img.shields.io/crates/v/hydra-engine-wds)](https://crates.io/crates/hydra-engine-wds)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://github.com/neeraip/hydra/blob/main/LICENSE)
+[![Cargo CI](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml/badge.svg)](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml)
+
+Core simulation engine for [Hydra](https://github.com/neeraip/hydra) — water distribution network data model, EPANET INP/OUT/RPT I/O, Global Gradient Algorithm hydraulic solver, Lagrangian water quality engine, simulation session API, and post-simulation analytics.
+
+> **Most users should depend on [`hydra-sdk`](https://crates.io/crates/hydra-sdk) instead.** `hydra-sdk` re-exports the complete public API of this crate as a single stable umbrella dependency.
+
+## Scope
+
+This crate owns:
+
+| Module | Responsibility |
+|---|---|
+| `model` | Network data model, state types, validation |
+| `io` | Unit conversion; INP parser; binary `.out` reader/writer; `.rpt` writer |
+| `hydraulics` | GGA Newton-Raphson solver |
+| `quality` | Lagrangian transport, mixing, reactions, source tracing |
+| `simulation` | Session API, controls, timestep orchestration, accounting |
+| `analysis` | Post-simulation analytics |
+
+This crate does **not** own interface logic (CLI, GUI) or filesystem/network I/O — callers supply bytes.
+
+## License
+
+[AGPL v3](https://github.com/neeraip/hydra/blob/main/LICENSE) — see [COMMERCIAL_LICENSE.md](https://github.com/neeraip/hydra/blob/main/.github/COMMERCIAL_LICENSE.md) for commercial licensing options.

--- a/crates/engine-wds/benches/solver.rs
+++ b/crates/engine-wds/benches/solver.rs
@@ -114,8 +114,8 @@ fn bench_network(c: &mut Criterion, name: &str) {
         }
     };
 
-    let network =
-        hydra_engine_wds::io::parse(&bytes).unwrap_or_else(|e| panic!("parse failed for {name}: {e}"));
+    let network = hydra_engine_wds::io::parse(&bytes)
+        .unwrap_or_else(|e| panic!("parse failed for {name}: {e}"));
     let favad = network.compute_favad();
 
     let init_nodes = init_node_states(&network);

--- a/crates/gui/frontend/src/components/modals/ScenariosModal.tsx
+++ b/crates/gui/frontend/src/components/modals/ScenariosModal.tsx
@@ -45,6 +45,7 @@ export function ScenariosModal() {
       {/* biome-ignore lint/a11y/noStaticElementInteractions: panel only stops backdrop clicks. */}
       <div
         onMouseDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}
         style={{
           width: "min(860px, 90vw)",

--- a/crates/gui/frontend/src/hooks/index.ts
+++ b/crates/gui/frontend/src/hooks/index.ts
@@ -298,10 +298,11 @@ export interface ScenarioDto {
  */
 export function useScenarios(
   projectId: string | null,
-  _version: number = 0,
+  version: number = 0,
 ): ScenarioDto[] {
   const [scenarios, setScenarios] = useState<ScenarioDto[]>([]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `version` is a caller-controlled refetch counter; it is a valid dep.
   useEffect(() => {
     if (!projectId) {
       setScenarios([]);
@@ -314,7 +315,7 @@ export function useScenarios(
     return () => {
       cancelled = true;
     };
-  }, [projectId, _version]);
+  }, [projectId, version]);
 
   return scenarios;
 }

--- a/crates/gui/frontend/src/pages/HomePage.tsx
+++ b/crates/gui/frontend/src/pages/HomePage.tsx
@@ -340,9 +340,7 @@ export function HomePage() {
                 </span>
                 <button
                   type="button"
-                  onClick={() =>
-                    openUrl(release.releaseUrl)
-                  }
+                  onClick={() => openUrl(release.releaseUrl)}
                   style={{
                     background: "transparent",
                     border: "none",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 description = "Water distribution network simulator — EPANET-compatible extended-period simulation"
+readme = "README.md"
 keywords = ["epanet", "water", "hydraulics", "simulation", "network"]
 categories = ["science", "simulation"]
 publish = true

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -1,0 +1,50 @@
+# hydra-sdk
+
+[![Crates.io](https://img.shields.io/crates/v/hydra-sdk)](https://crates.io/crates/hydra-sdk)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://github.com/neeraip/hydra/blob/main/LICENSE)
+[![Cargo CI](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml/badge.svg)](https://github.com/neeraip/hydra/actions/workflows/cargo-ci.yml)
+
+Water distribution network simulator — EPANET-compatible extended-period simulation.
+
+`hydra-sdk` is the user-facing library crate for [Hydra](https://github.com/neeraip/hydra). It re-exports the complete public API of `hydra-engine-wds` as a single stable dependency, with all internal crate versions pre-pinned.
+
+**[→ Full documentation](https://neeraip.github.io/hydra/sdk/overview.html)**
+
+## Install
+
+```toml
+[dependencies]
+hydra-sdk = "1"
+```
+
+## Quick start
+
+```rust
+use hydra_sdk::{io, Simulation, NodeQuantity, LinkQuantity};
+
+let bytes = std::fs::read("network.inp").unwrap();
+let network = io::parse(&bytes).unwrap();
+
+let mut sim = Simulation::create();
+sim.load(network).unwrap();
+sim.run().unwrap();
+
+for t in sim.snapshot_times() {
+    let head = sim.get_node_result("J1", NodeQuantity::Head, t).unwrap();
+    let flow = sim.get_link_result("P1", LinkQuantity::Flow, t).unwrap();
+    println!("t={t:.0}s  head={head:.3}  flow={flow:.6}");
+}
+```
+
+## What Hydra models
+
+- Extended-period steady-state hydraulics (Global Gradient Algorithm)
+- Pressure-driven and demand-driven demand models
+- Conservative and reactive constituent transport (water quality, age, source tracing)
+- EPANET 2.3 `.inp` format input; binary `.out` and plain-text `.rpt` output
+
+Hydra does **not** model pressure transients, water-hammer, or multi-phase flow.
+
+## License
+
+[AGPL v3](https://github.com/neeraip/hydra/blob/main/LICENSE) — see [COMMERCIAL_LICENSE.md](https://github.com/neeraip/hydra/blob/main/.github/COMMERCIAL_LICENSE.md) for commercial licensing options.


### PR DESCRIPTION
- Add README.md to crates/engine-wds, crates/sdk, crates/cli
- Wire readme = "README.md" in each [package]
- Add keywords and categories to hydra-engine-wds and hydra-cli
- Fix documentation URL (workspace) to https://neeraip.github.io/hydra/
- Collapse root README CLI section to a link → crates/cli/README.md
- Trim license footers in crate READMEs to single-line links
