### PR TITLE
ci: stop releases from evicting the caches every build depends on

### DIFF
--- a/.github/workflows/cargo-ci.yml
+++ b/.github/workflows/cargo-ci.yml
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: cargo-ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PRs only. A cancelled run never reaches its
+  # post-job cache save, and release pushes land in quick succession — with
+  # unconditional cancellation they repeatedly killed the cache-saving run,
+  # leaving every subsequent Windows job a ~20-minute cold build.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -49,6 +53,11 @@ jobs:
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Restore everywhere, save from main only: the repo cache budget is
+          # 10 GB, one saved trio of OS caches is ~4 GB, and PR/merge-ref
+          # saves were evicting the main caches every run depends on.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check dependencies (cargo-deny)
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
@@ -76,6 +85,11 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
+      # CI never attaches a debugger: skipping debuginfo roughly halves the
+      # cold Windows build (MSVC PDB generation and linking) and shrinks every
+      # cache. Backtraces still name frames via debug-assertions panics.
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
 
     steps:
       - name: Checkout repository
@@ -100,6 +114,11 @@ jobs:
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Restore everywhere, save from main only: the repo cache budget is
+          # 10 GB, one saved trio of OS caches is ~4 GB, and PR/merge-ref
+          # saves were evicting the main caches every run depends on.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: cargo test --workspace --all-targets --locked
@@ -147,6 +166,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.1
         with:
           key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests (latest stable)
         run: cargo +stable test --workspace --all-targets --locked

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -76,6 +76,13 @@ jobs:
           cache: false
 
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Release runs execute on tag refs. Caches saved under a tag ref can
+          # never be restored by any later run (each release is a new tag), so
+          # they were pure eviction pressure on the 10 GB budget — ~4 GB per
+          # release — pushing out the main-branch caches CI depends on.
+          # Restore from main's caches; never save.
+          save-if: false
 
       - uses: cargo-bins/cargo-binstall@v1.21.1
         if: matrix.cross
@@ -174,6 +181,13 @@ jobs:
           cache: false
 
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Release runs execute on tag refs. Caches saved under a tag ref can
+          # never be restored by any later run (each release is a new tag), so
+          # they were pure eviction pressure on the 10 GB budget — ~4 GB per
+          # release — pushing out the main-branch caches CI depends on.
+          # Restore from main's caches; never save.
+          save-if: false
 
       - uses: cargo-bins/cargo-binstall@v1.21.1
 


### PR DESCRIPTION
The 20-minute Windows test jobs were cold-cache builds, and the cache was cold for two compounding reasons, both release-driven.

Caches saved under tag refs are write-only: no later run can restore them (each release is a new tag), yet every release saved ~4 GB of them across three platforms — pure eviction pressure on the 10 GB repo budget, pushing out the main-branch caches CI restores from. The release workflow now restores from main and never saves.

Release pushes also land in quick succession, and the unconditional cancel-in-progress killed each in-flight main run before its post-job cache save executed — so the caches evicted by the tags were not being replaced either. Cancellation now applies to pull requests only; main runs complete and save.

Test builds additionally skip debuginfo (CARGO_PROFILE_DEV_DEBUG=0): CI never attaches a debugger, MSVC PDB generation dominates the cold Windows build, and the smaller artifacts halve each cache's footprint. PR and branch runs now restore but never save, so the budget holds one canonical trio of OS caches instead of a churn of variants.

The existing tag-ref and merge-ref caches are deleted; the live set is 5.3 GB, all restorable.