### PR TITLE
feat(uds)!: two-dimensional overland flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,17 @@
 
 Hydra is a water infrastructure simulation platform written in Rust, built as a suite of domain engines behind one shared toolchain (CLI, desktop GUI, Rust SDK).
 
-Two engines are implemented today. The **water distribution** engine (`wds`) implements the Global Gradient Algorithm (GGA) hydraulic solver and a Lagrangian water quality engine on the EPANET data model (any 2.x input; the format is specified against 2.3). The **urban drainage** engine (`uds`) implements rainfall-runoff hydrology, Preissmann-slot dynamic-wave routing, and water quality on the SWMM data model; it is available from the CLI, the SDK, and the GUI, where a drainage model is imported, then edited, run and explored. For both, correctness is defined by Hydra's own convergence criteria and physical conservation laws.
+Two engines are implemented today. The **water distribution** engine (`wds`) implements the Global Gradient Algorithm (GGA) hydraulic solver and a Lagrangian water quality engine on the EPANET data model (any 2.x input; the format is specified against 2.3). The **urban drainage** engine (`uds`) implements rainfall-runoff hydrology, Preissmann-slot dynamic-wave routing, two-dimensional overland flow coupled to the network (spec §15), and water quality on the SWMM data model; it is available from the CLI, the SDK, and the GUI, where a drainage model is imported, then edited, run and explored. The GUI runs mesh models but does not yet render their surfaces. For both, correctness is defined by Hydra's own convergence criteria and physical conservation laws.
 
-**2D overland flow** is planned as future functionality of the `uds` engine,
-not as a separate engine: SWMM's own data model is gaining 2D simulation
-upstream (SWMM6) on the same input format, so Hydra's path to 2D is growing
-`uds`, spec-first, when that work begins. There was once a third planned
+**2D overland flow** is functionality of the `uds` engine, not a separate
+engine: the overland sections ride the SWMM input format (specs
+`crates/engine-uds/src/overland/spec.md` §15 and interop §14.15–§14.16),
+mirroring the direction SWMM's own data model is taking upstream (SWMM6).
+There was once a third planned
 engine — **open channel** (`och`, HEC-RAS data model) — withdrawn in favour
 of this plan. Its registry key and crate name (`hydra-engine-och`, published
 as an empty scaffold through workspace v12) stay reserved and must never be
-reused for a different domain. Never write copy that implies `uds` simulates
-2D overland flow today, and never resurrect `och` in docs or interfaces.
+reused for a different domain. Never resurrect `och` in docs or interfaces.
 
 The engine registry's `EngineStatus::Planned` variant is permanent machinery
 and stays, even while no planned engine is registered.
@@ -82,6 +82,7 @@ authoritative definition of Hydra's mathematical behaviour:
 | `crates/engine-uds/src/hydrology/spec.md` | Runoff, infiltration, LID, snowmelt, groundwater, RDII, climate |
 | `crates/engine-uds/src/hydraulics/spec.md` | Section geometry, dynamic-wave routing, structures, inlets |
 | `crates/engine-uds/src/transport/spec.md` | Buildup, washoff, treatment, network transport |
+| `crates/engine-uds/src/overland/spec.md` | Two-dimensional overland flow: mesh, marcher, coupling, meteorology, conservation |
 | `crates/engine-uds/src/simulation/spec.md` | Controls, orchestration, accounting, statistics, session API |
 | `crates/engine-uds/src/report_blocks/spec.md` | Post-simulation analytics: report-block catalog, derivations, options |
 | `crates/engine-uds/src/interop/spec.md` | INP import, interface files, OUT/RPT output, recognition |

--- a/crates/cli/src/uds_cmd.rs
+++ b/crates/cli/src/uds_cmd.rs
@@ -448,6 +448,23 @@ pub(crate) fn run(args: &RunArgs, cli: &Cli, bytes: Vec<u8>) -> i32 {
         }
     }
 
+    // §14.16: a mesh model's overland results stream to a sidecar
+    // alongside the §14.9 file.
+    if let Some(out_path) = args.results.as_deref() {
+        if es.as_uds().is_some_and(Simulation::has_overland) {
+            let p2 = two_d_results_path(out_path);
+            let attach = std::fs::File::create(&p2).and_then(|f| {
+                es.as_uds_mut()
+                    .expect("checked above")
+                    .begin_overland_results(Box::new(std::io::BufWriter::new(f)))
+            });
+            if let Err(e) = attach {
+                emit_error("io/output", &format!("{p2}: {e}"), None, None);
+                return EXIT_IO;
+            }
+        }
+    }
+
     let mut progress = ProgressReporter::new(std::io::stderr().is_terminal() && !cli.quiet);
     progress.startup_banner();
     if let Err(code) = crate::drive_with_progress(&mut es, &mut progress) {
@@ -768,5 +785,27 @@ J1  0  0
     fn aux_files_refuse_http_models() {
         let err = resolve_aux_path("https://example.com/net.inp", "climate.dat");
         assert_eq!(err.unwrap_err(), EXIT_INPUT);
+    }
+}
+
+/// The §14.16 sidecar's path beside the §14.9 results file: `run.out`
+/// becomes `run.2d.out`, and a path without the extension gains it.
+fn two_d_results_path(out_path: &str) -> String {
+    match out_path.strip_suffix(".out") {
+        Some(stem) => format!("{stem}.2d.out"),
+        None => format!("{out_path}.2d.out"),
+    }
+}
+
+#[cfg(test)]
+mod overland_path_tests {
+    use super::two_d_results_path;
+
+    /// The sidecar lands beside the results file, named after it.
+    #[test]
+    fn the_sidecar_is_named_after_the_results_file() {
+        assert_eq!(two_d_results_path("run.out"), "run.2d.out");
+        assert_eq!(two_d_results_path("a/b/city.out"), "a/b/city.2d.out");
+        assert_eq!(two_d_results_path("results"), "results.2d.out");
     }
 }

--- a/crates/cli/src/uds_cmd.rs
+++ b/crates/cli/src/uds_cmd.rs
@@ -187,12 +187,40 @@ pub(crate) fn run(args: &RunArgs, cli: &Cli, bytes: Vec<u8>) -> i32 {
     // beside the one the open is about to build. Two parsed networks of a
     // large model is tens of megabytes for no reason.
     let iface = net.interface_files.clone();
+    // §14.15: a declared external mesh file is the caller's to read,
+    // like every auxiliary.
+    let mesh_file = net.overland.as_ref().and_then(|m| m.mesh_file.clone());
     drop(net);
+    let mesh_text = match &mesh_file {
+        Some(name) => {
+            let path = match resolve_aux_path(&args.model, name) {
+                Ok(p) => p,
+                Err(code) => return code,
+            };
+            match std::fs::read_to_string(&path) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    emit_error(
+                        "io/mesh",
+                        &format!("mesh file {}: {e}", path.display()),
+                        None,
+                        None,
+                    );
+                    return EXIT_IO;
+                }
+            }
+        }
+        None => None,
+    };
 
     // ── Open: parse, validate, build ──────────────────────────────────────────
-    let opened = match &rain_iface {
-        Some(bytes) => Simulation::open_with_rain_interface(&text, climate_records, bytes),
-        None => Simulation::open_with_rain_records(&text, climate_records, rain_files),
+    // A model with an external mesh cannot run yet (§1.8), so the mesh
+    // path needs no combination with the climate and rain paths: it
+    // exists so the refusal and IGNORE_2D behaviours see the real mesh.
+    let opened = match (&mesh_text, &rain_iface) {
+        (Some(mesh), _) => Simulation::open_with_overland_mesh(&text, mesh),
+        (None, Some(bytes)) => Simulation::open_with_rain_interface(&text, climate_records, bytes),
+        (None, None) => Simulation::open_with_rain_records(&text, climate_records, rain_files),
     };
     let (mut sim, diags, findings) = match opened {
         Ok(session) => session,
@@ -583,7 +611,13 @@ pub(crate) fn run(args: &RunArgs, cli: &Cli, bytes: Vec<u8>) -> i32 {
 /// would change line numbers in a diagnostic the survey never emits but a
 /// reader might still compare against.
 fn survey_sections(text: &str) -> String {
-    const WANTED: [&str; 4] = ["[OPTIONS]", "[TEMPERATURE]", "[FILES]", "[RAINGAGES]"];
+    const WANTED: [&str; 5] = [
+        "[OPTIONS]",
+        "[TEMPERATURE]",
+        "[FILES]",
+        "[RAINGAGES]",
+        "[2D_MESH_FILE",
+    ];
     let mut out = String::new();
     let mut keep = true;
     for line in text.lines() {

--- a/crates/cli/src/uds_cmd.rs
+++ b/crates/cli/src/uds_cmd.rs
@@ -216,7 +216,9 @@ pub(crate) fn run(args: &RunArgs, cli: &Cli, bytes: Vec<u8>) -> i32 {
             emit_error("input/unsupported", &s.to_string(), None, None);
             return EXIT_INPUT;
         }
-        Err(OpenError::Controls(msg)) | Err(OpenError::Transport(msg)) => {
+        Err(OpenError::Controls(msg))
+        | Err(OpenError::Transport(msg))
+        | Err(OpenError::Overland(msg)) => {
             emit_error("input/unsupported", &msg, None, None);
             return EXIT_INPUT;
         }

--- a/crates/demo/src/run.rs
+++ b/crates/demo/src/run.rs
@@ -592,7 +592,7 @@ fn open_uds(
             EXIT_INPUT,
             Diagnostic::error("input/unsupported", s.to_string()),
         ),
-        OpenError::Controls(msg) | OpenError::Transport(msg) => {
+        OpenError::Controls(msg) | OpenError::Transport(msg) | OpenError::Overland(msg) => {
             Failure::one(EXIT_INPUT, Diagnostic::error("input/unsupported", msg))
         }
     })?;

--- a/crates/engine-uds/src/hydraulics/routing.rs
+++ b/crates/engine-uds/src/hydraulics/routing.rs
@@ -594,6 +594,10 @@ struct Vert {
     /// A gated outfall: reverse flow through any connecting link is
     /// blocked (§2.6).
     gated: bool,
+    /// §15.6: coupled to the overland mesh — ponding-capable regardless
+    /// of the global option, ponded area = the mesh median-dual
+    /// footprint, and the §6.4 area takes the exchange conductance.
+    coupled: bool,
     class: VertClass,
 }
 
@@ -680,6 +684,15 @@ pub struct Router {
     err_tol: f64,
     allow_ponding: bool,
     normal_flow: NormalFlowCriteria,
+    /// §15.6: per-outfall 2D tailwater (surface elevation m, wetness
+    /// ramp in \[0, 1\]), consulted inside every iteration's boundary
+    /// evaluation. Sentinel (−∞, 0) = no coupled surface.
+    tail_2d: Vec<(f64, f64)>,
+    /// §15.6: per-vertex exchange conductance (m²/s per m of head, i.e.
+    /// m²·s⁻¹·m⁻¹ = m/s·m — dimensionally an area per time once
+    /// multiplied by Δt), refreshed by the session each routing period;
+    /// zero everywhere no coupling exists.
+    coupling_g: Vec<f64>,
     // State (accepted).
     t: f64,
     y: Vec<f64>,
@@ -1124,6 +1137,7 @@ impl Router {
                 ponded_area: ponded,
                 crown: 0.0,
                 gated,
+                coupled: false,
                 class,
             });
         }
@@ -1513,6 +1527,8 @@ impl Router {
             continuity_tol: net.options.continuity_tol,
             err_tol: net.options.routing_err_tol,
             allow_ponding: net.options.allow_ponding,
+            coupling_g: vec![0.0; net.vertices.len()],
+            tail_2d: vec![(f64::NEG_INFINITY, 0.0); net.vertices.len()],
             normal_flow: net.options.normal_flow,
             t: 0.0,
             y: vec![0.0; nv],
@@ -1727,6 +1743,50 @@ impl Router {
 
     /// Set a fixed-stage outfall's stage elevation (m) — the session's
     /// handle for tidal and series boundaries (§10.1).
+    /// §15.6: mark a vertex as coupled to the overland mesh. Its ponded
+    /// area becomes the mesh's median-dual footprint and ponding applies
+    /// there regardless of the global option.
+    pub fn set_coupled(&mut self, vi: usize, footprint: f64) {
+        self.verts[vi].coupled = true;
+        self.verts[vi].ponded_area = footprint;
+    }
+
+    /// §15.6: refresh a coupled vertex's exchange conductance for the
+    /// coming period. Clamped non-negative — the term only ever damps.
+    pub fn set_coupling_conductance(&mut self, vi: usize, g: f64) {
+        self.coupling_g[vi] = g.max(0.0);
+    }
+
+    /// §15.6: set a coupled outfall's 2D tailwater for the coming
+    /// period — the surface elevation over the deepest wet stencil cell
+    /// and the wetness ramp that blends it in. Every iteration's
+    /// boundary evaluation consults it; a flap gate (`gated`) keeps the
+    /// surface from pushing water back into the network.
+    pub fn set_outfall_tailwater(&mut self, vi: usize, h_2d: f64, ramp: f64) {
+        self.tail_2d[vi] = (h_2d, ramp.clamp(0.0, 1.0));
+    }
+
+    /// §15.6: the net link flow arriving at a vertex right now (m³/s,
+    /// positive toward the vertex) — a coupled outfall's discharge.
+    pub fn vertex_net_link_inflow(&self, vi: usize) -> f64 {
+        let mut q = 0.0;
+        for (ci, c) in self.chans.iter().enumerate() {
+            if c.to == vi {
+                q += self.q[ci];
+            } else if c.from == vi {
+                q -= self.q[ci];
+            }
+        }
+        for (si, st) in self.structs.iter().enumerate() {
+            if st.to == vi {
+                q += self.sq[si];
+            } else if st.from == vi {
+                q -= self.sq[si];
+            }
+        }
+        q
+    }
+
     pub fn set_outfall_stage(&mut self, vi: usize, elev: f64) {
         if let VertClass::Outfall(Boundary::Fixed(e)) = &mut self.verts[vi].class {
             *e = elev;
@@ -3175,11 +3235,15 @@ impl Router {
                             if let VertClass::Storage(g) = &v.class {
                                 area += g.area(y_i);
                             }
-                            let ponded = self.allow_ponding && v.ponded_area > 0.0 && y_i > v.y_max;
+                            let ponded = (self.allow_ponding || v.coupled)
+                                && v.ponded_area > 0.0
+                                && y_i > v.y_max;
                             if ponded {
                                 area = v.ponded_area;
                             }
-                            let area = area.max(self.min_surface_area);
+                            // §15.6: the exchange conductance damps the
+                            // update at a coupled vertex.
+                            let area = area.max(self.min_surface_area) + self.coupling_g[vi] * dt;
                             let net_i = *net_p.get().add(vi);
                             let dv = 0.5 * (self.net_flow[vi] + net_i) * dt;
                             let y_raw = self.y[vi] + dv / area;
@@ -3192,7 +3256,9 @@ impl Router {
                             }
                             let cap = v.y_max + v.surcharge;
                             let mut fl = 0.0;
-                            if y_new > cap && !(self.allow_ponding && v.ponded_area > 0.0) {
+                            if y_new > cap
+                                && !((self.allow_ponding || v.coupled) && v.ponded_area > 0.0)
+                            {
                                 fl = (y_raw - cap).max(0.0) * area / dt;
                                 y_new = cap;
                             }
@@ -3534,11 +3600,15 @@ impl Router {
                         if let VertClass::Storage(g) = &v.class {
                             area += g.area(y[vi]);
                         }
-                        let ponded = self.allow_ponding && v.ponded_area > 0.0 && y[vi] > v.y_max;
+                        let ponded = (self.allow_ponding || v.coupled)
+                            && v.ponded_area > 0.0
+                            && y[vi] > v.y_max;
                         if ponded {
                             area = v.ponded_area;
                         }
-                        let area = area.max(self.min_surface_area);
+                        // §15.6: the exchange conductance damps the update
+                        // at a coupled vertex.
+                        let area = area.max(self.min_surface_area) + self.coupling_g[vi] * dt;
                         let dv = 0.5 * (self.net_flow[vi] + net_new[vi]) * dt;
                         // The mass balance, before relaxation touches it.
                         let y_raw = self.y[vi] + dv / area;
@@ -3560,7 +3630,9 @@ impl Router {
                         // all. At a vertex held at its rim for hours that
                         // is a factor of ω off the flood volume.
                         let cap = v.y_max + v.surcharge;
-                        if y_new > cap && !(self.allow_ponding && v.ponded_area > 0.0) {
+                        if y_new > cap
+                            && !((self.allow_ponding || v.coupled) && v.ponded_area > 0.0)
+                        {
                             flood[vi] = (y_raw - cap).max(0.0) * area / dt;
                             y_new = cap;
                         }
@@ -4168,6 +4240,24 @@ impl Router {
     }
 
     fn outfall_depth(&self, vi: usize, b: &Boundary, q: &[f64]) -> f64 {
+        let y_std = self.outfall_depth_standard(vi, b, q);
+        // §15.6: a coupled outfall blends toward the surface tailwater
+        // by the wetness ramp; a flap gate suppresses the override when
+        // the surface stands above the stage the outfall would
+        // otherwise carry.
+        let (h_2d, ramp) = self.tail_2d[vi];
+        let v = &self.verts[vi];
+        if h_2d > v.invert && ramp > 0.0 {
+            let h_std = v.invert + y_std;
+            if !(v.gated && h_2d > h_std) {
+                let h_blend = h_std + ramp * (h_2d - h_std).max(0.0);
+                return h_blend - v.invert;
+            }
+        }
+        y_std
+    }
+
+    fn outfall_depth_standard(&self, vi: usize, b: &Boundary, q: &[f64]) -> f64 {
         match b {
             // §2.6: a staged condition governs only where it exceeds the
             // critical-depth elevation; below that the brink controls,
@@ -5480,6 +5570,73 @@ C1  CIRCULAR  0.3  0  0  0
         );
     }
 
+    /// §15.6: a coupled vertex ponds over its mesh footprint regardless
+    /// of the global ponding option — the pond there is the overland
+    /// surface itself — while the same overloaded uncoupled vertex pins
+    /// at its rim and floods.
+    #[test]
+    fn a_coupled_vertex_ponds_without_the_global_option() {
+        let inp = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+ROUTING_STEP  5
+
+[JUNCTIONS]
+J1  100.2  0.6
+
+[OUTFALLS]
+O1  100.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.3  0  0  0
+";
+        let (_, mut r) = build(inp);
+        r.set_coupled(0, 25.0);
+        r.advance(1800.0, &inflow_at(0, 0.2));
+        assert!(r.y[0] > 0.6, "head must rise above the rim, y = {}", r.y[0]);
+        assert_eq!(r.report.flooding, 0.0, "a coupled vertex never floods");
+    }
+
+    /// §15.6: the exchange conductance augments the coupled vertex's
+    /// §6.4 storage, so the same inflow raises its head less.
+    #[test]
+    fn the_coupling_conductance_damps_the_vertex() {
+        let inp = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+ROUTING_STEP  5
+
+[JUNCTIONS]
+J1  100.2  2.0
+
+[OUTFALLS]
+O1  100.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.3  0  0  0
+";
+        let (_, mut plain) = build(inp);
+        plain.advance(60.0, &inflow_at(0, 0.05));
+        let (_, mut damped) = build(inp);
+        damped.set_coupling_conductance(0, 5.0);
+        damped.advance(60.0, &inflow_at(0, 0.05));
+        assert!(
+            damped.y[0] < plain.y[0],
+            "damped {} vs plain {}",
+            damped.y[0],
+            plain.y[0]
+        );
+        // Clamped non-negative: a negative setting is a no-op.
+        damped.set_coupling_conductance(0, -3.0);
+        assert_eq!(damped.coupling_g[0], 0.0);
+    }
+
     /// An outfall opens at the depth its boundary imposes (§6.7), and the
     /// channel reaching it opens holding that water.
     ///
@@ -6358,6 +6515,8 @@ impl Router {
             err_tol: _,
             allow_ponding: _,
             normal_flow: _,
+            coupling_g: _,
+            tail_2d: _,
             stor_evap_frac: _,
             stor_seep_ksat: _,
             // State.

--- a/crates/engine-uds/src/hydraulics/spec.md
+++ b/crates/engine-uds/src/hydraulics/spec.md
@@ -526,7 +526,11 @@ algebraic special case. The assembled area is floored at a documented minimum
 (`min_surface_area`, default 1.167 m², the plan area of a 1.22 m (4 ft)
 manhole) —
 a physical floor, since a real access structure has real plan area, not a
-numerical fiction.
+numerical fiction. At a vertex coupled to the overland mesh (§15.6) the
+assembled area is further augmented by the exchange conductance,
+$A_S + G\,\Delta t$: the coupling is a lagged source with a steep head
+sensitivity, and the added term is exactly the damping that keeps this
+iteration stable against it.
 
 ### 6.4 Iteration
 
@@ -856,7 +860,11 @@ user-supplied flow limit, when given, caps $\lvert Q \rvert$ every iteration.
 ground elevation (plus any surcharge allowance) is pinned there, the surplus
 inflow leaving the system as reported flooding. With ponding enabled the
 surplus accumulates over the vertex's ponded area — a virtual store whose
-head may rise above ground — and drains back as capacity recovers.
+head may rise above ground — and drains back as capacity recovers. A vertex
+coupled to the overland mesh (§15.6) is ponding-capable regardless of the
+global option, its ponded area the mesh's median-dual footprint: the pond
+there is not a modelling choice but the overland surface itself, and the
+grade must track it.
 
 ### 6.7 Initial Conditions
 

--- a/crates/engine-uds/src/interop/spec.md
+++ b/crates/engine-uds/src/interop/spec.md
@@ -148,7 +148,10 @@ owning specification section for its semantics. The nine display-metadata
 sections (`[MAP]`, `[COORDINATES]`, `[VERTICES]`, `[POLYGONS]`, `[SYMBOLS]`,
 `[LABELS]`, `[BACKDROP]`, `[TAGS]`, `[PROFILES]`) carry no engine semantics:
 they are parsed for well-formedness only and preserved verbatim for writers,
-so applications may consume them and a load-and-save cycle keeps them.
+so applications may consume them and a load-and-save cycle keeps them. One
+recorded exception: when a model carries an overland mesh, `[SYMBOLS]`
+supplies the rain-gauge positions §15.7's interpolation reads — the
+predecessor's convention, adopted with it (§14.15).
 
 Within the per-object property sections — external inflows, sanitary
 inflows, sewer inflows, treatment, land cover, and initial loadings — a
@@ -1390,3 +1393,103 @@ than silently ignored.
 > *Source: `climate.c:climate_openFile` seeding `FileValue[TMIN]` and
 > `[TMAX]` from `Temp.ta`, `project.c:915` setting that to 70.0, and
 > `updateFileValues`, `if ( FileData[i][FileDay] == MISSING ) continue;`.*
+
+### 14.15 Two-Dimensional Sections
+
+The overland-flow input vocabulary (§15) is the successor format's — the
+community continuation whose 6.x line grows two-dimensional simulation on
+this same file format — adopted section for section. A mesh activates §15;
+`IGNORE_2D YES` in `[OPTIONS]` keeps the sections parsed and preserved but
+runs the model one-dimensional, with notice. Until §15 is served (§1.8),
+every section below receives §14.2's unrecognised-section treatment.
+
+**Sections.** Whitespace-tokenised per §14.2. Vertices and cells are
+implicitly indexed from zero in file order.
+
+- `[2D_VERTICES]` — `X Y Z [TAG]`: position and ground elevation in the
+  model's length units, optional tag.
+- `[2D_TRIANGLES]` — `V1 V2 V3 MANNINGS_N [INIT_DEPTH] [TAG]`: three
+  vertex indices, Manning roughness (> 0), optional initial depth
+  (default 0). The fifth column is initial depth when numeric and a tag
+  otherwise (the historical four-column-plus-tag form); a written file
+  always carries the depth when a tag is present, so round-trips are
+  unambiguous. Winding order is free.
+- `[2D_INITIAL_VELOCITY]` — `TRI U V`: an initial velocity (m/s) for a
+  cell, seeding face discharges by projection. Follows `[2D_TRIANGLES]`.
+- `[2D_VERTEX_NODE_MAP]` / `[2D_TRIANGLE_NODE_MAP]` — `INDEX_OR_TAG NODE
+  [CD] [AREA]`: a coupling point (§15.6) joining a mesh vertex or cell to
+  a node; discharge coefficient default 0.65, exchange area default
+  1.0 m² in the model's units (an unauthored area is eligible for
+  `COUPLING_AREA AUTO`). The first token is an index where numeric and in
+  range, else a tag. One coupling per vertex (a later row replaces);
+  repeated triangle rows accumulate, several nodes to one cell.
+- `[2D_BOUNDARY_CONDITIONS]` — `TRI EDGE TYPE [PARAM_1 [PARAM_2
+  [GROUP]]]`: attaches a §15.5 condition to a boundary edge; local edge
+  `e` is the edge opposite vertex `e`. Types `WALL`, `NORMAL_FLOW`
+  (parameter: slope), `SPECIFIED_STAGE` (stage) and `TS_STAGE` (series
+  name), `SPECIFIED_FLOW` (per-metre discharge in the model's flow units
+  per metre) and `TS_FLOW` (series name), `RATING_CURVE` (curve of stage
+  above the edge bed against per-metre discharge). `PARAM_2` is reserved
+  and written `*`. Unaddressed boundary edges are walls.
+- `[2D_EDGE_CONVEYANCE]` — `FROM_VERTEX TO_VERTEX FACTOR`: the §15.2
+  conveyance ψ ∈ [0, 1] of the undirected interior edge between two
+  vertices.
+- `[2D_MESH_FILE]` — `FILE <path>`: an external file, resolved against
+  the model's location and supplied in memory by the caller like every
+  §14.8 auxiliary, carrying the same sections (nested mesh files
+  excluded). Only the first `FILE` line is honoured. The `.2dm`
+  extension is conventional; the content is this grammar, not the SMS
+  format of that name.
+
+**Units.** Mesh coordinates, elevations, depths and areas are authored in
+the model's display units and convert at import, unless the mesh carries
+the header comment `;; UNITS: SI (m)` (either in the model or the
+external file), which declares it SI already. The header can only assert
+SI: a US declaration is ignored, as the predecessor's is. Boundary stages
+convert as elevations; boundary flows convert per the model's flow unit.
+
+**`[2D_OPTIONS]`.** `PARAMETER VALUE` per line, case-insensitive:
+
+| Key | Default | §15 meaning |
+|---|---|---|
+| `INTEGRATOR` | `EXPLICIT` | the only value; others are retired |
+| `CFL_NUMBER` | 0.7 | §15.4.4 α |
+| `MAX_TIMESTEP` | 10 s | §15.4.4 cap |
+| `THETA` | 0.8 | §15.4.2 θ |
+| `FROUDE_MAX` | 1.5 | §15.4.2 cap |
+| `LTS_TIERS` | 4 | §15.4.4 tiers (1–8) |
+| `H_MOVE` | 0.003 m | §15.4.4 activation threshold |
+| `DRY_DEPTH` | 0.001 m | §15.4.2 dry gate |
+| `CELL_CLOSURE` | `FLAT` | or `VFR` (§15.3) |
+| `FACE_RECONSTRUCTION` | `MEAN` | or `VFR_FACE` (§15.3) |
+| `VFR_MIN_WET_FRAC` | 0.01 | §15.3 ε, (0, 0.5] |
+| `ADVECTION` | `NO` | §15.4.6 convective term |
+| `RAINFALL_MODE` | `NATURAL_NEIGHBOUR` | or `SYSTEM`, `NONE` (§15.7) |
+| `COUPLING_AREA` | `DEFAULT` | or `AUTO` (§15.6) |
+| `COUPLING_CD` | 0.65 | default discharge coefficient for coupling rows without their own |
+| `COUPLING_SYNC` | 0 s | §15.6 batching; 0 couples per routing step |
+| `REPORT_2D` | `YES` | §15.10 results gap governs what this yields |
+| `OUTPUT_FILE` | none | §15.10 results gap |
+
+> **CORRESPONDENCE:** the predecessor parses `COUPLING_CD` and writes it
+> back, but its solve path never reads it — per-point coefficients come
+> only from the map rows or the hard-coded default. This engine honours
+> the option as its name says. `LIMITER_EPSILON` and `FLUX_DH_EPS` are
+> likewise accepted and inert here: both belong to the predecessor's
+> retired flux machinery, and files that carry them mean nothing by them.
+
+**Retired keys** — the predecessor's implicit-integrator vocabulary
+(`MIN_TIMESTEP`, `REL_TOLERANCE`, `ABS_TOLERANCE`, `MAX_CVODE_STEPS`,
+`MAX_KRYLOV_DIM`, `LINEAR_SOLVER`, `PRECONDITIONER`, `JACOBIAN`,
+`ATOL_AREA_REF`, `COUPLING_INTERVAL`, `COUPLING_WINDOW`, `ACTIVE_SET`,
+`ACTIVE_SET_HALO`, `MOMENTUM`, and non-`EXPLICIT` integrators) — warn
+and are ignored, so files from any predecessor vintage open. The same
+treatment absorbs keys this table does not carry: the predecessor is
+pre-release and its option vocabulary churns; an unknown 2D option warns
+and is ignored rather than refusing the file, and adopting a new key is
+an amendment to this table.
+
+**Import warnings.** A model with both parcels and mesh rainfall warns of
+the §15.7 double count. A coupling area more than ten times the node's
+largest connected conduit warns. A node whose rim sits outside the mesh's
+elevation envelope by more than a sanity margin warns of a datum mismatch.

--- a/crates/engine-uds/src/interop/spec.md
+++ b/crates/engine-uds/src/interop/spec.md
@@ -1493,3 +1493,12 @@ an amendment to this table.
 the §15.7 double count. A coupling area more than ten times the node's
 largest connected conduit warns. A node whose rim sits outside the mesh's
 elevation envelope by more than a sanity margin warns of a datum mismatch.
+
+**Export.** A model carrying a mesh writes every 2D section it holds,
+always in SI under a `;; UNITS: SI (m)` header — the one representation
+that round-trips losslessly whatever units the model was authored in,
+and one the predecessor reads. Cells always write their initial depth
+when they carry a tag, so the fifth column stays unambiguous
+(§14.13's columns rule). An external mesh file is not re-created:
+export inlines the mesh it holds, and the `[2D_MESH_FILE]` declaration
+is not written.

--- a/crates/engine-uds/src/interop/spec.md
+++ b/crates/engine-uds/src/interop/spec.md
@@ -746,7 +746,12 @@ including the process-model checklist; the control-actions log; the runoff
 quantity and quality continuity balances; the flow routing and quality
 routing continuity balances; the highest continuity errors, time-step
 critical elements, flow instability indexes, and non-converging vertices;
-the routing time-step summary; then the per-object summary tables —
+the routing time-step summary; for a run serving an overland mesh
+(§15), the overland flow continuity balance and the overland time-step
+summary, in that order, between the routing continuity balances and the
+highest-continuity-errors list — blocks the predecessor never prints
+because it cannot run a mesh model, laid out in the house style of
+their neighbours; then the per-object summary tables —
 subcatchment runoff, control-measure performance, subcatchment washoff,
 node depth, node inflow, node
 surcharge, node flooding, storage volume, outfall loading, link flow, flow
@@ -771,9 +776,20 @@ predecessor's must never mistake bookkeeping for physics.
 
 **`[REPORT]` gates the body**, as it does in the predecessor. `DISABLED`
 suppresses everything the run produced, leaving the banner. `CONTINUITY`
-gates the four continuity balances, `FLOWSTATS` the diagnostics and the
-routing time-step summary together, and `CONTROLS` the control-actions
-log. The highest continuity errors list names the vertices whose own §11.1
+gates the four continuity balances (and the overland one with them),
+`FLOWSTATS` the diagnostics and the routing time-step summary together
+(and the overland time-step summary with them), and `CONTROLS` the
+control-actions log. The overland flow continuity balance prints the
+§15.8 ledger as volume rows — initial storage, rainfall, evaporation,
+junction drainage, junction spill, outfall injection, outfall
+withdrawal, boundary inflow, boundary outflow, final storage — and its
+closure as the continuity error, in the report's volume units. The
+flow routing continuity balance of a coupled run additionally carries
+the §15.8 named pair, surface drainage among its inflows and surface
+spill among its outflows, and its error term accounts for both. The
+overland time-step summary prints the march's whole-run counts: base
+substeps, macro cycles, active-set rebuilds, the minimum and average
+base step, and the peak active-cell count (§15.4.4). The highest continuity errors list names the vertices whose own §11.1
 balance closes worst, skipping terminal vertices — with nothing leaving by
 a link the balance says nothing about the solver — and vertices that barely
 saw water, below the predecessor's threshold of a tenth of a cubic foot,
@@ -1502,3 +1518,58 @@ when they carry a tag, so the fifth column stays unambiguous
 (§14.13's columns rule). An external mesh file is not re-created:
 export inlines the mesh it holds, and the `[2D_MESH_FILE]` declaration
 is not written.
+
+### 14.16 The Overland Results Stream
+
+The §14.9 binary results file is the predecessor's format, and the
+predecessor's format has no vocabulary for a mesh: its object classes
+are fixed, its readers are third parties, and nothing may be appended
+to it. Overland results therefore stream to a **sidecar file** in this
+engine's own format, written alongside the §14.9 file at the same
+reporting instants. The predecessor writes CF/UGRID HDF5 instead; that
+choice needs a native library this engine's browser constraint (§1.4)
+refuses, and a reader for it is a foreign dependency either way, so
+the sidecar is this engine's own framed layout, fully specified here.
+One engine writes it and the same engine reads it back; nothing about
+it is a compatibility surface with the predecessor.
+
+Everything is little-endian. The clock, the geometry and the ledger
+are eight-byte floats; per-cell record values are four-byte floats,
+the resolution every reported result in §14.9 already has. All values
+are SI (§14.15): metres, seconds, cubic metres per second. The file
+has three parts:
+
+**Header.** Leading magic `1214727218`, format version `1`, then the
+counts — vertices, cells, coupling points — as four-byte unsigned
+integers; the reporting clock (start epoch seconds, report step
+seconds, first instant's run time seconds) as floats; then the mesh
+geometry a viewer renders without the model: each vertex's $x, y, z$,
+then each cell's three vertex indices, then each coupling point's
+cell index.
+
+**Records**, one per reporting instant, fixed size:
+
+- the instant's run time (s, eight-byte float);
+- per cell, in index order: depth (m), surface elevation (m), and the
+  velocity components $u, v$ (m/s) from the §15.4.3 reconstruction,
+  zero where the cell holds less than the drying depth;
+- per coupling point, in point order: the exchange rate over the
+  reporting period (m³/s, positive draining into the network);
+- the §15.8 ledger, cumulative since the start of the run, as ten
+  eight-byte floats: surface storage now, rainfall in, evaporation
+  out, junction drainage out, junction spill in, outfall injection
+  in, outfall withdrawal out, boundary in, boundary out, and the
+  continuity error as a signed volume.
+
+**Epilog.** The record count as a four-byte signed integer, then the
+closing magic. A file without its epilog is a run that did not finish,
+and a reader says so rather than serving the torso as complete.
+
+**Reading** follows §14.9's carve-out for the same reason: a mesh
+run's results dwarf everything else the run owns, so the reader
+operates on an explicitly supplied path and seeks — the header, one
+record, one cell's series across all records, or a sequential scan —
+rather than requiring the whole file in memory. Opening validates the
+leading and closing magic, the version, and that header, fixed-size
+records and epilog tile the file exactly.
+

--- a/crates/engine-uds/src/io/hydrology.rs
+++ b/crates/engine-uds/src/io/hydrology.rs
@@ -115,6 +115,7 @@ pub(crate) fn parse_gages(
             continue;
         };
         gages.push(Gage {
+            position: None,
             id: t[0].to_string(),
             form,
             interval,

--- a/crates/engine-uds/src/io/inp_writer.rs
+++ b/crates/engine-uds/src/io/inp_writer.rs
@@ -315,6 +315,7 @@ pub fn write_inp(network: &Network) -> Result<String, ExportRefusal> {
     write_tables(network, &u, &mut out);
     write_timeseries(network, &mut out);
     write_admin(network, &mut out);
+    write_overland(network, &mut out);
     write_display(network, &mut out);
     out.trim_start_matches('\n')
         .to_string()
@@ -2527,6 +2528,198 @@ fn write_tables(network: &Network, u: &Units, out: &mut String) {
 /// The nine display-metadata sections, written from what import
 /// preserved (§14.5): verbatim, in their original order, neither
 /// validated nor normalised.
+/// §14.15 export: every 2D section the model holds, always in SI under
+/// the `;; UNITS: SI (m)` header — the one representation that
+/// round-trips losslessly whatever units the model was authored in. An
+/// external mesh file is inlined, never re-created.
+fn write_overland(network: &Network, out: &mut String) {
+    use crate::overland::{
+        BoundaryCondition, CellClosure, FaceReconstruction, OverlandOptions, RainfallMode,
+        SeriesOrValue,
+    };
+    let Some(mesh) = &network.overland else {
+        return;
+    };
+    let defaults = OverlandOptions::default();
+    let o = &mesh.options;
+    let _ = writeln!(out, "\n[2D_OPTIONS]\n;; UNITS: SI (m)");
+    let mut opt = |key: &str, val: String| {
+        let _ = writeln!(out, "{key:<20} {val}");
+    };
+    if o.cfl_number != defaults.cfl_number {
+        opt("CFL_NUMBER", format!("{}", o.cfl_number));
+    }
+    if o.max_timestep != defaults.max_timestep {
+        opt("MAX_TIMESTEP", format!("{}", o.max_timestep));
+    }
+    if o.theta != defaults.theta {
+        opt("THETA", format!("{}", o.theta));
+    }
+    if o.froude_max != defaults.froude_max {
+        opt("FROUDE_MAX", format!("{}", o.froude_max));
+    }
+    if o.lts_tiers != defaults.lts_tiers {
+        opt("LTS_TIERS", format!("{}", o.lts_tiers));
+    }
+    if o.h_move != defaults.h_move {
+        opt("H_MOVE", format!("{}", o.h_move));
+    }
+    if o.dry_depth != defaults.dry_depth {
+        opt("DRY_DEPTH", format!("{}", o.dry_depth));
+    }
+    if o.cell_closure != defaults.cell_closure {
+        opt(
+            "CELL_CLOSURE",
+            match o.cell_closure {
+                CellClosure::Flat => "FLAT".into(),
+                CellClosure::Vfr => "VFR".into(),
+            },
+        );
+    }
+    if o.face_reconstruction != defaults.face_reconstruction {
+        opt(
+            "FACE_RECONSTRUCTION",
+            match o.face_reconstruction {
+                FaceReconstruction::Mean => "MEAN".into(),
+                FaceReconstruction::VfrFace => "VFR_FACE".into(),
+            },
+        );
+    }
+    if o.vfr_min_wet_frac != defaults.vfr_min_wet_frac {
+        opt("VFR_MIN_WET_FRAC", format!("{}", o.vfr_min_wet_frac));
+    }
+    if o.advection != defaults.advection {
+        opt(
+            "ADVECTION",
+            if o.advection {
+                "YES".into()
+            } else {
+                "NO".into()
+            },
+        );
+    }
+    if o.rainfall_mode != defaults.rainfall_mode {
+        opt(
+            "RAINFALL_MODE",
+            match o.rainfall_mode {
+                RainfallMode::NaturalNeighbour => "NATURAL_NEIGHBOUR".into(),
+                RainfallMode::System => "SYSTEM".into(),
+                RainfallMode::None => "NONE".into(),
+            },
+        );
+    }
+    if o.coupling_area_auto != defaults.coupling_area_auto {
+        opt("COUPLING_AREA", "AUTO".into());
+    }
+    if o.coupling_cd != defaults.coupling_cd {
+        opt("COUPLING_CD", format!("{}", o.coupling_cd));
+    }
+    if o.coupling_sync != defaults.coupling_sync {
+        opt("COUPLING_SYNC", format!("{}", o.coupling_sync));
+    }
+    if o.report_2d != defaults.report_2d {
+        opt(
+            "REPORT_2D",
+            if o.report_2d {
+                "YES".into()
+            } else {
+                "NO".into()
+            },
+        );
+    }
+    if let Some(file) = &o.output_file {
+        opt("OUTPUT_FILE", file.clone());
+    }
+
+    let _ = writeln!(out, "\n[2D_VERTICES]");
+    for v in &mesh.verts {
+        match &v.tag {
+            Some(tag) => {
+                let _ = writeln!(out, "{} {} {} {tag}", v.x, v.y, v.z);
+            }
+            None => {
+                let _ = writeln!(out, "{} {} {}", v.x, v.y, v.z);
+            }
+        }
+    }
+
+    let _ = writeln!(out, "\n[2D_TRIANGLES]");
+    for c in &mesh.cells {
+        // §14.15: the depth always writes when a tag follows it, so the
+        // fifth column stays unambiguous.
+        match (&c.tag, c.h0 != 0.0) {
+            (Some(tag), _) => {
+                let _ = writeln!(
+                    out,
+                    "{} {} {} {} {} {tag}",
+                    c.v[0], c.v[1], c.v[2], c.n, c.h0
+                );
+            }
+            (None, true) => {
+                let _ = writeln!(out, "{} {} {} {} {}", c.v[0], c.v[1], c.v[2], c.n, c.h0);
+            }
+            (None, false) => {
+                let _ = writeln!(out, "{} {} {} {}", c.v[0], c.v[1], c.v[2], c.n);
+            }
+        }
+    }
+
+    if !mesh.init_velocity.is_empty() {
+        let _ = writeln!(out, "\n[2D_INITIAL_VELOCITY]");
+        for r in &mesh.init_velocity {
+            let _ = writeln!(out, "{} {} {}", r.cell, r.u, r.v);
+        }
+    }
+    // An unauthored exchange area stays unwritten: baking the default in
+    // would pin a row that COUPLING_AREA AUTO is entitled to derive
+    // (§15.6), and the grammar carries a coefficient without an area.
+    let coupling_line = |out: &mut String, r: &crate::overland::CouplingRow| {
+        if r.area_authored {
+            let _ = writeln!(out, "{} {} {} {}", r.address, r.node, r.cd, r.area);
+        } else {
+            let _ = writeln!(out, "{} {} {}", r.address, r.node, r.cd);
+        }
+    };
+    if !mesh.vertex_couplings.is_empty() {
+        let _ = writeln!(out, "\n[2D_VERTEX_NODE_MAP]");
+        for r in &mesh.vertex_couplings {
+            coupling_line(out, r);
+        }
+    }
+    if !mesh.cell_couplings.is_empty() {
+        let _ = writeln!(out, "\n[2D_TRIANGLE_NODE_MAP]");
+        for r in &mesh.cell_couplings {
+            coupling_line(out, r);
+        }
+    }
+    if !mesh.boundaries.is_empty() {
+        let _ = writeln!(out, "\n[2D_BOUNDARY_CONDITIONS]");
+        for b in &mesh.boundaries {
+            let (ty, p1) = match &b.condition {
+                BoundaryCondition::Wall => ("WALL", "*".to_string()),
+                BoundaryCondition::NormalFlow { slope } => ("NORMAL_FLOW", format!("{slope}")),
+                BoundaryCondition::Stage(SeriesOrValue::Value(v)) => {
+                    ("SPECIFIED_STAGE", format!("{v}"))
+                }
+                BoundaryCondition::Stage(SeriesOrValue::Series(name)) => ("TS_STAGE", name.clone()),
+                BoundaryCondition::Flow(SeriesOrValue::Value(v)) => {
+                    ("SPECIFIED_FLOW", format!("{v}"))
+                }
+                BoundaryCondition::Flow(SeriesOrValue::Series(name)) => ("TS_FLOW", name.clone()),
+                BoundaryCondition::RatingCurve { curve } => ("RATING_CURVE", curve.clone()),
+            };
+            let group = b.group.as_deref().unwrap_or("*");
+            let _ = writeln!(out, "{} {} {ty} {p1} * {group}", b.cell, b.edge);
+        }
+    }
+    if !mesh.conveyance.is_empty() {
+        let _ = writeln!(out, "\n[2D_EDGE_CONVEYANCE]");
+        for r in &mesh.conveyance {
+            let _ = writeln!(out, "{} {} {}", r.from, r.to, r.factor);
+        }
+    }
+}
+
 fn write_display(network: &Network, out: &mut String) {
     for section in &network.display {
         if section.lines.is_empty() {

--- a/crates/engine-uds/src/io/keywords.rs
+++ b/crates/engine-uds/src/io/keywords.rs
@@ -99,6 +99,17 @@ pub enum Section {
     Streets,
     InletUsage,
     Inlets,
+    /// §14.15 overland sections. Recognised so a mesh model parses and
+    /// validates; §1.8 governs whether a run serves it.
+    TwoDOptions,
+    TwoDVertices,
+    TwoDTriangles,
+    TwoDInitialVelocity,
+    TwoDVertexNodeMap,
+    TwoDTriangleNodeMap,
+    TwoDBoundaryConditions,
+    TwoDEdgeConveyance,
+    TwoDMeshFile,
 }
 
 impl Section {
@@ -197,6 +208,39 @@ pub const SECTIONS: &[(&str, &str, Section)] = &[
     ("[STREET", "[STREETS]", Section::Streets),
     ("[INLET_USAGE", "[INLET_USAGE]", Section::InletUsage),
     ("[INLET", "[INLETS]", Section::Inlets),
+    // §14.15 overland sections. `[2D_TRIANGLE_NODE_MAP` and
+    // `[2D_TRIANGLES` share the stem `[2D_TRIANGLE`; the underscore
+    // after it separates them, and the longer is listed first anyway,
+    // the `[INLET_USAGE` convention. Same for the vertex pair.
+    ("[2D_OPTION", "[2D_OPTIONS]", Section::TwoDOptions),
+    (
+        "[2D_VERTEX_NODE_MAP",
+        "[2D_VERTEX_NODE_MAP]",
+        Section::TwoDVertexNodeMap,
+    ),
+    ("[2D_VERTICES", "[2D_VERTICES]", Section::TwoDVertices),
+    (
+        "[2D_TRIANGLE_NODE_MAP",
+        "[2D_TRIANGLE_NODE_MAP]",
+        Section::TwoDTriangleNodeMap,
+    ),
+    ("[2D_TRIANGLES", "[2D_TRIANGLES]", Section::TwoDTriangles),
+    (
+        "[2D_INITIAL_VELOCITY",
+        "[2D_INITIAL_VELOCITY]",
+        Section::TwoDInitialVelocity,
+    ),
+    (
+        "[2D_BOUNDARY_CONDITION",
+        "[2D_BOUNDARY_CONDITIONS]",
+        Section::TwoDBoundaryConditions,
+    ),
+    (
+        "[2D_EDGE_CONVEYANCE",
+        "[2D_EDGE_CONVEYANCE]",
+        Section::TwoDEdgeConveyance,
+    ),
+    ("[2D_MESH_FILE", "[2D_MESH_FILE]", Section::TwoDMeshFile),
 ];
 
 /// A section-header match: which section, and whether the token was the
@@ -309,6 +353,26 @@ mod tests {
             .position(|(p, _, _)| *p == "[INLET")
             .unwrap();
         assert!(iu < i, "[INLET_USAGE must precede [INLET");
-        assert_eq!(SECTIONS.len(), 57);
+        // The §14.15 pairs sharing a stem: the node maps must precede
+        // their geometry sections, the `[INLET_USAGE` convention.
+        let vm = SECTIONS
+            .iter()
+            .position(|(p, _, _)| *p == "[2D_VERTEX_NODE_MAP")
+            .unwrap();
+        let v = SECTIONS
+            .iter()
+            .position(|(p, _, _)| *p == "[2D_VERTICES")
+            .unwrap();
+        assert!(vm < v, "[2D_VERTEX_NODE_MAP must precede [2D_VERTICES");
+        let tm = SECTIONS
+            .iter()
+            .position(|(p, _, _)| *p == "[2D_TRIANGLE_NODE_MAP")
+            .unwrap();
+        let t = SECTIONS
+            .iter()
+            .position(|(p, _, _)| *p == "[2D_TRIANGLES")
+            .unwrap();
+        assert!(tm < t, "[2D_TRIANGLE_NODE_MAP must precede [2D_TRIANGLES");
+        assert_eq!(SECTIONS.len(), 66);
     }
 }

--- a/crates/engine-uds/src/io/mod.rs
+++ b/crates/engine-uds/src/io/mod.rs
@@ -18,6 +18,7 @@ pub mod options;
 pub mod out_reader;
 pub mod out_writer;
 pub mod overland;
+pub mod overland_out;
 pub mod quality;
 pub mod rain;
 pub mod rpt_writer;

--- a/crates/engine-uds/src/io/mod.rs
+++ b/crates/engine-uds/src/io/mod.rs
@@ -17,6 +17,7 @@ pub mod objects;
 pub mod options;
 pub mod out_reader;
 pub mod out_writer;
+pub mod overland;
 pub mod quality;
 pub mod rain;
 pub mod rpt_writer;
@@ -43,6 +44,15 @@ use hydra_common::Recognition;
 /// mirror image of the water-distribution engine's pair (its model spec
 /// §4.1.3), so any INP file both engines see gets complementary verdicts.
 const SWMM_ONLY_SECTIONS: &[&str] = &[
+    "2D_BOUNDARY_CONDITIONS",
+    "2D_EDGE_CONVEYANCE",
+    "2D_INITIAL_VELOCITY",
+    "2D_MESH_FILE",
+    "2D_OPTIONS",
+    "2D_TRIANGLES",
+    "2D_TRIANGLE_NODE_MAP",
+    "2D_VERTEX_NODE_MAP",
+    "2D_VERTICES",
     "ADJUSTMENTS",
     "AQUIFERS",
     "CONDUITS",

--- a/crates/engine-uds/src/io/objects.rs
+++ b/crates/engine-uds/src/io/objects.rs
@@ -372,6 +372,36 @@ pub fn parse_network(input: &str) -> (Network, Vec<Diagnostic>) {
         &mut diagnostics,
     );
 
+    // §15.7: with a mesh present, `[SYMBOLS]` supplies the rain-gauge
+    // positions the rainfall interpolation reads — the one recorded
+    // exception to display metadata's semantics-free rule (§14.5). The
+    // coordinates share the mesh's unit handling: display units unless
+    // the SI header asserted otherwise.
+    if net.overland.is_some() {
+        let vlen = if overland_units_si { 1.0 } else { cv.len };
+        for (sec, lines) in &s.sections {
+            if *sec != Section::Symbols {
+                continue;
+            }
+            for line in lines {
+                let t = &line.tokens;
+                if t.len() < 3 {
+                    continue;
+                }
+                let (Ok(x), Ok(y)) = (t[1].finite_f64(), t[2].finite_f64()) else {
+                    continue;
+                };
+                if let Some(g) = net
+                    .gages
+                    .iter_mut()
+                    .find(|g| g.id.eq_ignore_ascii_case(t[0]))
+                {
+                    g.position = Some((x * vlen, y * vlen));
+                }
+            }
+        }
+    }
+
     (net, diagnostics)
 }
 
@@ -397,7 +427,7 @@ pub(crate) struct UnitConverter {
 }
 
 impl UnitConverter {
-    fn new(units: FlowUnits, offsets: LinkOffsets) -> Self {
+    pub(crate) fn new(units: FlowUnits, offsets: LinkOffsets) -> Self {
         let us = units.is_us();
         UnitConverter {
             len: units.m_per_length_unit(),

--- a/crates/engine-uds/src/io/objects.rs
+++ b/crates/engine-uds/src/io/objects.rs
@@ -57,6 +57,10 @@ pub fn parse_network(input: &str) -> (Network, Vec<Diagnostic>) {
 
     let cv = UnitConverter::new(options.flow_units, options.link_offsets);
 
+    // §14.15: the overland mesh, when the model authors one. The SI
+    // header is a raw-text prescan — comments never reach the tokens.
+    let overland_units_si = super::overland::units_header_si(input);
+
     // Data objects (§2.9), before the graph that references them.
     let empty = std::collections::HashMap::new();
     for (sec, lines) in &s.sections {
@@ -360,6 +364,14 @@ pub fn parse_network(input: &str) -> (Network, Vec<Diagnostic>) {
     }
 
     net.options = options;
+    net.overland = super::overland::parse_overland(
+        &s.sections,
+        overland_units_si,
+        cv.len,
+        cv.flow,
+        &mut diagnostics,
+    );
+
     (net, diagnostics)
 }
 

--- a/crates/engine-uds/src/io/options.rs
+++ b/crates/engine-uds/src/io/options.rs
@@ -193,6 +193,9 @@ pub struct AnalysisOptions {
     pub ignore_rdii: bool,
     /// Ignore flow routing (also set by `FLOW_ROUTING NONE`).
     pub ignore_routing: bool,
+    /// Keep the overland mesh parsed and preserved but run the model
+    /// one-dimensional (§14.15 `IGNORE_2D`).
+    pub ignore_overland: bool,
     /// Ignore constituent transport.
     pub ignore_quality: bool,
     /// Wet hydrology step (s); default 300.
@@ -265,6 +268,7 @@ impl Default for AnalysisOptions {
             ignore_groundwater: false,
             ignore_rdii: false,
             ignore_routing: false,
+            ignore_overland: false,
             ignore_quality: false,
             wet_step: 300.0,
             dry_step: 3600.0,
@@ -352,6 +356,7 @@ const OPTION_WORDS: &[&str] = &[
     "MINIMUM_STEP",
     "THREADS",
     "SURCHARGE_METHOD",
+    "IGNORE_2D",
 ];
 
 /// Parse an `[OPTIONS]` section's lines into resolved [`AnalysisOptions`],
@@ -510,6 +515,7 @@ pub fn parse_options(
             }
             "IGNORE_RDII" => set_bool(&mut o.ignore_rdii, keyword, value, l, diagnostics),
             "IGNORE_ROUTING" => set_bool(&mut o.ignore_routing, keyword, value, l, diagnostics),
+            "IGNORE_2D" => set_bool(&mut o.ignore_overland, keyword, value, l, diagnostics),
             "IGNORE_QUALITY" => set_bool(&mut o.ignore_quality, keyword, value, l, diagnostics),
             "LINK_OFFSETS" => {
                 if let Some(v) = enum_value(&["DEPTH", "ELEVATION"], keyword, value, l, diagnostics)

--- a/crates/engine-uds/src/io/out_reader.rs
+++ b/crates/engine-uds/src/io/out_reader.rs
@@ -367,3 +367,218 @@ pub fn read_element_series(
     }
     Ok(ElementSeries { epochs_s, vars })
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// §14.16: the overland results stream's reader — the same carve-out,
+// for the same reason: a mesh run's results dwarf everything else the
+// run owns, so this reader seeks an explicitly supplied path.
+// ═══════════════════════════════════════════════════════════════════
+
+use super::overland_out::{
+    header_len, record_len, LedgerRow, MAGIC as OV_MAGIC, VERSION as OV_VERSION,
+};
+
+fn ov_read_u32(f: &mut File) -> Result<u32, String> {
+    let mut b = [0u8; 4];
+    f.read_exact(&mut b).map_err(|e| e.to_string())?;
+    Ok(u32::from_le_bytes(b))
+}
+
+fn ov_read_f64(f: &mut File) -> Result<f64, String> {
+    let mut b = [0u8; 8];
+    f.read_exact(&mut b).map_err(|e| e.to_string())?;
+    Ok(f64::from_le_bytes(b))
+}
+
+fn ov_read_f32(f: &mut File) -> Result<f32, String> {
+    let mut b = [0u8; 4];
+    f.read_exact(&mut b).map_err(|e| e.to_string())?;
+    Ok(f32::from_le_bytes(b))
+}
+
+/// One §14.16 record: an instant's whole surface.
+#[derive(Debug, Clone)]
+pub struct OverlandRecord {
+    /// Run time (s).
+    pub t: f64,
+    /// Per cell: depth (m), surface elevation (m), velocity u, v (m/s).
+    pub cells: Vec<[f32; 4]>,
+    /// Per coupling point: exchange rate (m³/s, positive draining).
+    pub exchange: Vec<f32>,
+    /// The §15.8 ledger, cumulative (m³).
+    pub ledger: LedgerRow,
+}
+
+/// An open §14.16 overland results file: header held, records served
+/// by seeking.
+#[derive(Debug)]
+pub struct OverlandResults {
+    path: std::path::PathBuf,
+    /// Vertex positions and elevations (m).
+    pub verts: Vec<(f64, f64, f64)>,
+    /// Cell vertex triples.
+    pub cells: Vec<[u32; 3]>,
+    /// Each coupling point's cell.
+    pub point_cells: Vec<u32>,
+    /// The reporting clock: start epoch (s), report step (s), first
+    /// instant's run time (s).
+    pub start_epoch: f64,
+    pub report_step: f64,
+    pub first_report_t: f64,
+    /// Record count from the epilog.
+    pub periods: usize,
+    records_at: u64,
+}
+
+impl OverlandResults {
+    /// Open and validate: both magic numbers, the version, and that
+    /// header, fixed-size records and epilog tile the file exactly. A
+    /// file without its epilog is a run that did not finish, refused
+    /// as such rather than served as complete.
+    pub fn open(path: &Path) -> Result<OverlandResults, String> {
+        let ctx = |e: String| format!("{}: {e}", path.display());
+        let mut f = File::open(path).map_err(|e| ctx(e.to_string()))?;
+        let len = f.metadata().map_err(|e| ctx(e.to_string()))?.len();
+        if ov_read_u32(&mut f).map_err(ctx)? != OV_MAGIC {
+            return Err(format!("{}: not an overland results file", path.display()));
+        }
+        let version = ov_read_u32(&mut f).map_err(ctx)?;
+        if version != OV_VERSION {
+            return Err(format!(
+                "{}: overland results version {version}, this reader serves {OV_VERSION}",
+                path.display()
+            ));
+        }
+        let nv = ov_read_u32(&mut f).map_err(ctx)? as usize;
+        let nc = ov_read_u32(&mut f).map_err(ctx)? as usize;
+        let np = ov_read_u32(&mut f).map_err(ctx)? as usize;
+        let start_epoch = ov_read_f64(&mut f).map_err(ctx)?;
+        let report_step = ov_read_f64(&mut f).map_err(ctx)?;
+        let first_report_t = ov_read_f64(&mut f).map_err(ctx)?;
+        let head = header_len(nv, nc, np);
+        let rec = record_len(nc, np);
+        if len < head + 8 {
+            return Err(format!(
+                "{}: the run this file records did not finish (no epilog)",
+                path.display()
+            ));
+        }
+        // Epilog: record count then the closing magic.
+        f.seek(SeekFrom::End(-8)).map_err(|e| ctx(e.to_string()))?;
+        let mut b = [0u8; 4];
+        f.read_exact(&mut b).map_err(|e| ctx(e.to_string()))?;
+        let periods = i32::from_le_bytes(b);
+        if ov_read_u32(&mut f).map_err(ctx)? != OV_MAGIC {
+            return Err(format!(
+                "{}: the run this file records did not finish (no epilog)",
+                path.display()
+            ));
+        }
+        if periods < 0 || head + rec * periods as u64 + 8 != len {
+            return Err(format!(
+                "{}: header, records and epilog do not tile the file",
+                path.display()
+            ));
+        }
+        // The geometry, read once.
+        f.seek(SeekFrom::Start((4 * 5 + 8 * 3) as u64))
+            .map_err(|e| ctx(e.to_string()))?;
+        let mut verts = Vec::with_capacity(nv);
+        for _ in 0..nv {
+            let x = ov_read_f64(&mut f).map_err(ctx)?;
+            let y = ov_read_f64(&mut f).map_err(ctx)?;
+            let z = ov_read_f64(&mut f).map_err(ctx)?;
+            verts.push((x, y, z));
+        }
+        let mut cells = Vec::with_capacity(nc);
+        for _ in 0..nc {
+            let a = ov_read_u32(&mut f).map_err(ctx)?;
+            let b = ov_read_u32(&mut f).map_err(ctx)?;
+            let c = ov_read_u32(&mut f).map_err(ctx)?;
+            cells.push([a, b, c]);
+        }
+        let mut point_cells = Vec::with_capacity(np);
+        for _ in 0..np {
+            point_cells.push(ov_read_u32(&mut f).map_err(ctx)?);
+        }
+        Ok(OverlandResults {
+            path: path.to_path_buf(),
+            verts,
+            cells,
+            point_cells,
+            start_epoch,
+            report_step,
+            first_report_t,
+            periods: periods as usize,
+            records_at: head,
+        })
+    }
+
+    /// One record, by index.
+    pub fn record(&self, i: usize) -> Result<OverlandRecord, String> {
+        if i >= self.periods {
+            return Err(format!(
+                "{}: record {i} of {}",
+                self.path.display(),
+                self.periods
+            ));
+        }
+        let ctx = |e: String| format!("{}: {e}", self.path.display());
+        let mut f = File::open(&self.path).map_err(|e| ctx(e.to_string()))?;
+        let (nc, np) = (self.cells.len(), self.point_cells.len());
+        f.seek(SeekFrom::Start(
+            self.records_at + record_len(nc, np) * i as u64,
+        ))
+        .map_err(|e| ctx(e.to_string()))?;
+        let t = ov_read_f64(&mut f).map_err(ctx)?;
+        let mut cells = Vec::with_capacity(nc);
+        for _ in 0..nc {
+            let mut c = [0.0f32; 4];
+            for v in &mut c {
+                *v = ov_read_f32(&mut f).map_err(ctx)?;
+            }
+            cells.push(c);
+        }
+        let mut exchange = Vec::with_capacity(np);
+        for _ in 0..np {
+            exchange.push(ov_read_f32(&mut f).map_err(ctx)?);
+        }
+        let mut ledger = [0.0f64; 10];
+        for v in &mut ledger {
+            *v = ov_read_f64(&mut f).map_err(ctx)?;
+        }
+        Ok(OverlandRecord {
+            t,
+            cells,
+            exchange,
+            ledger: LedgerRow::from_array(ledger),
+        })
+    }
+
+    /// One cell's series across every record: (t, depth, surface
+    /// elevation, u, v).
+    pub fn cell_series(&self, ci: usize) -> Result<Vec<(f64, [f32; 4])>, String> {
+        let (nc, np) = (self.cells.len(), self.point_cells.len());
+        if ci >= nc {
+            return Err(format!("{}: cell {ci} of {nc}", self.path.display()));
+        }
+        let ctx = |e: String| format!("{}: {e}", self.path.display());
+        let mut f = File::open(&self.path).map_err(|e| ctx(e.to_string()))?;
+        let rec = record_len(nc, np);
+        let mut out = Vec::with_capacity(self.periods);
+        for i in 0..self.periods {
+            let at = self.records_at + rec * i as u64;
+            f.seek(SeekFrom::Start(at))
+                .map_err(|e| ctx(e.to_string()))?;
+            let t = ov_read_f64(&mut f).map_err(ctx)?;
+            f.seek(SeekFrom::Start(at + 8 + 16 * ci as u64))
+                .map_err(|e| ctx(e.to_string()))?;
+            let mut c = [0.0f32; 4];
+            for v in &mut c {
+                *v = ov_read_f32(&mut f).map_err(ctx)?;
+            }
+            out.push((t, c));
+        }
+        Ok(out)
+    }
+}

--- a/crates/engine-uds/src/io/overland.rs
+++ b/crates/engine-uds/src/io/overland.rs
@@ -1,0 +1,778 @@
+//! §14.15: the overland-mesh input sections.
+//!
+//! Everything here binds the successor format's `[2D_*]` grammar to the
+//! §15.2 model: field orders, defaults, the index-or-tag addressing rule,
+//! the one-way SI header, and display-unit conversion. Semantics live in
+//! §15; this module never interprets the mesh, only reads it.
+
+use super::keywords::{match_keyword, Section};
+use super::lex::FiniteParse;
+use super::survey::{Diagnostic, DiagnosticKind, TokenLine};
+use crate::overland::{
+    BoundaryCondition, BoundaryRow, CellClosure, ConveyanceRow, CouplingRow, FaceReconstruction,
+    InitVelocityRow, MeshCell, MeshVertex, OverlandMesh, OverlandOptions, RainfallMode,
+    SeriesOrValue,
+};
+
+fn err(line: usize, kind: DiagnosticKind) -> Diagnostic {
+    Diagnostic { line, kind }
+}
+
+fn bad(line: usize, token: &str) -> Diagnostic {
+    Diagnostic {
+        line,
+        kind: DiagnosticKind::BadValue {
+            token: token.to_string(),
+        },
+    }
+}
+
+/// The §14.15 retired-key vocabulary: the predecessor's implicit-solver
+/// options, warned and ignored so files of any vintage open, plus the
+/// two keys its retired flux machinery left behind.
+const RETIRED_KEYS: &[&str] = &[
+    "MIN_TIMESTEP",
+    "REL_TOLERANCE",
+    "ABS_TOLERANCE",
+    "MAX_CVODE_STEPS",
+    "MAX_KRYLOV_DIM",
+    "LINEAR_SOLVER",
+    "PRECONDITIONER",
+    "JACOBIAN",
+    "ATOL_AREA_REF",
+    "COUPLING_INTERVAL",
+    "COUPLING_WINDOW",
+    "ACTIVE_SET",
+    "ACTIVE_SET_HALO",
+    "MOMENTUM",
+    "LIMITER_EPSILON",
+    "FLUX_DH_EPS",
+];
+
+/// Scan raw model text for the §14.15 mesh-units header. The header can
+/// only assert SI — a US declaration is ignored, as the predecessor's is
+/// — and any `;; UNITS:` line in the text counts, the last one winning
+/// by virtue of overwriting nothing (asserting SI twice is asserting SI).
+pub(crate) fn units_header_si(text: &str) -> bool {
+    let mut si = false;
+    for line in text.lines() {
+        let t = line.trim();
+        let Some(rest) = t.strip_prefix(";;") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(value) = rest
+            .strip_prefix("UNITS:")
+            .or_else(|| rest.strip_prefix("units:"))
+            .or_else(|| rest.strip_prefix("Units:"))
+        else {
+            continue;
+        };
+        let v = value.trim().to_ascii_uppercase();
+        if v.starts_with("SI") || v == "M" || v.starts_with("METRE") || v.starts_with("METER") {
+            si = true;
+        }
+    }
+    si
+}
+
+/// Parse every §14.15 section into the §15.2 mesh model. `None` when the
+/// model carries no overland input at all. `len` is the display-length
+/// factor (m per file length unit) and `flow` the display-flow factor
+/// (m³/s per file flow unit); both are bypassed for lengths when the SI
+/// header asserted the mesh is already metric.
+pub(crate) fn parse_overland(
+    sections: &[(Section, Vec<TokenLine<'_>>)],
+    units_si: bool,
+    len: f64,
+    flow: f64,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<OverlandMesh> {
+    let present = sections.iter().any(|(sec, _)| {
+        matches!(
+            sec,
+            Section::TwoDOptions
+                | Section::TwoDVertices
+                | Section::TwoDTriangles
+                | Section::TwoDInitialVelocity
+                | Section::TwoDVertexNodeMap
+                | Section::TwoDTriangleNodeMap
+                | Section::TwoDBoundaryConditions
+                | Section::TwoDEdgeConveyance
+                | Section::TwoDMeshFile
+        )
+    });
+    if !present {
+        return None;
+    }
+
+    let vlen = if units_si { 1.0 } else { len };
+    let mut mesh = OverlandMesh {
+        units_si,
+        ..Default::default()
+    };
+
+    // Geometry first: the addressed sections resolve indices and tags
+    // against it, whatever order the file wrote its sections in.
+    for (sec, lines) in sections {
+        match sec {
+            Section::TwoDOptions => parse_options(lines, &mut mesh.options, diags),
+            Section::TwoDVertices => parse_vertices(lines, vlen, &mut mesh.verts, diags),
+            Section::TwoDTriangles => parse_cells(lines, vlen, &mut mesh.cells, diags),
+            Section::TwoDMeshFile => parse_mesh_file(lines, &mut mesh.mesh_file, diags),
+            _ => {}
+        }
+    }
+    for (sec, lines) in sections {
+        match sec {
+            Section::TwoDInitialVelocity => {
+                parse_init_velocity(lines, mesh.cells.len(), &mut mesh.init_velocity, diags);
+            }
+            Section::TwoDVertexNodeMap => {
+                parse_couplings(lines, Addr::Vertex, &mesh, vlen, diags)
+                    .into_iter()
+                    .for_each(|row| upsert_vertex_coupling(&mut mesh.vertex_couplings, row));
+            }
+            Section::TwoDTriangleNodeMap => {
+                let rows = parse_couplings(lines, Addr::Cell, &mesh, vlen, diags);
+                mesh.cell_couplings.extend(rows);
+            }
+            Section::TwoDBoundaryConditions => {
+                parse_boundaries(lines, vlen, flow, &mut mesh.boundaries, diags);
+            }
+            Section::TwoDEdgeConveyance => {
+                parse_conveyance(lines, &mut mesh.conveyance, diags);
+            }
+            _ => {}
+        }
+    }
+    Some(mesh)
+}
+
+/// §14.15: one coupling per vertex — a later row replaces the earlier.
+fn upsert_vertex_coupling(rows: &mut Vec<CouplingRow>, row: CouplingRow) {
+    match rows.iter_mut().find(|r| r.mesh_index == row.mesh_index) {
+        Some(existing) => *existing = row,
+        None => rows.push(row),
+    }
+}
+
+fn parse_vertices(
+    lines: &[TokenLine<'_>],
+    vlen: f64,
+    out: &mut Vec<MeshVertex>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 3 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let (Ok(x), Ok(y), Ok(z)) = (t[0].finite_f64(), t[1].finite_f64(), t[2].finite_f64())
+        else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        out.push(MeshVertex {
+            x: x * vlen,
+            y: y * vlen,
+            z: z * vlen,
+            tag: t.get(3).map(|s| s.to_string()),
+        });
+    }
+}
+
+fn parse_cells(
+    lines: &[TokenLine<'_>],
+    vlen: f64,
+    out: &mut Vec<MeshCell>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 4 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let (Ok(v0), Ok(v1), Ok(v2)) = (
+            t[0].parse::<u32>(),
+            t[1].parse::<u32>(),
+            t[2].parse::<u32>(),
+        ) else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        let Ok(n) = t[3].finite_f64() else {
+            diags.push(bad(line.line, t[3]));
+            continue;
+        };
+        // §14.15: the fifth column is a depth when numeric, a tag
+        // otherwise; the sixth is a tag when the depth is present.
+        let (h0, tag) = match t.get(4) {
+            None => (0.0, None),
+            Some(fifth) => match fifth.finite_f64() {
+                Ok(d) => (d * vlen, t.get(5).map(|s| s.to_string())),
+                Err(()) => (0.0, Some(fifth.to_string())),
+            },
+        };
+        if h0 < 0.0 {
+            diags.push(bad(line.line, t[4]));
+            continue;
+        }
+        out.push(MeshCell {
+            v: [v0, v1, v2],
+            n,
+            h0,
+            tag,
+        });
+    }
+}
+
+fn parse_init_velocity(
+    lines: &[TokenLine<'_>],
+    n_cells: usize,
+    out: &mut Vec<InitVelocityRow>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 3 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let Ok(cell) = t[0].parse::<u32>() else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        if cell as usize >= n_cells {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        }
+        let (Ok(u), Ok(v)) = (t[1].finite_f64(), t[2].finite_f64()) else {
+            diags.push(bad(line.line, t[1]));
+            continue;
+        };
+        out.push(InitVelocityRow { cell, u, v });
+    }
+}
+
+/// Which list a coupling row addresses.
+enum Addr {
+    Vertex,
+    Cell,
+}
+
+/// §14.15's addressing rule: the first token is an index where numeric
+/// and in range, else a tag — so purely numeric tags still resolve.
+fn resolve_addr(token: &str, addr: &Addr, mesh: &OverlandMesh) -> Option<u32> {
+    let count = match addr {
+        Addr::Vertex => mesh.verts.len(),
+        Addr::Cell => mesh.cells.len(),
+    };
+    if let Ok(i) = token.parse::<u32>() {
+        if (i as usize) < count {
+            return Some(i);
+        }
+    }
+    let by_tag = |tag: &Option<String>| tag.as_deref() == Some(token);
+    match addr {
+        Addr::Vertex => mesh.verts.iter().position(|v| by_tag(&v.tag)),
+        Addr::Cell => mesh.cells.iter().position(|c| by_tag(&c.tag)),
+    }
+    .map(|i| i as u32)
+}
+
+fn parse_couplings(
+    lines: &[TokenLine<'_>],
+    addr: Addr,
+    mesh: &OverlandMesh,
+    vlen: f64,
+    diags: &mut Vec<Diagnostic>,
+) -> Vec<CouplingRow> {
+    let mut rows = Vec::new();
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 2 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let Some(mesh_index) = resolve_addr(t[0], &addr, mesh) else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        let cd = match t.get(2) {
+            None => mesh.options.coupling_cd,
+            Some(tok) => match tok.finite_f64() {
+                Ok(v) => v,
+                Err(()) => {
+                    diags.push(bad(line.line, tok));
+                    continue;
+                }
+            },
+        };
+        let (area, area_authored) = match t.get(3) {
+            None => (1.0, false),
+            Some(tok) => match tok.finite_f64() {
+                Ok(v) => (v * vlen * vlen, true),
+                Err(()) => {
+                    diags.push(bad(line.line, tok));
+                    continue;
+                }
+            },
+        };
+        rows.push(CouplingRow {
+            mesh_index,
+            node: t[1].to_string(),
+            cd,
+            area,
+            area_authored,
+        });
+    }
+    rows
+}
+
+fn parse_boundaries(
+    lines: &[TokenLine<'_>],
+    vlen: f64,
+    flow: f64,
+    out: &mut Vec<BoundaryRow>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    const TYPES: &[&str] = &[
+        "WALL",
+        "NORMAL_FLOW",
+        "SPECIFIED_STAGE",
+        "TS_STAGE",
+        "SPECIFIED_FLOW",
+        "TS_FLOW",
+        "RATING_CURVE",
+    ];
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 3 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let (Ok(cell), Ok(edge)) = (t[0].parse::<u32>(), t[1].parse::<u8>()) else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        if edge > 2 {
+            diags.push(bad(line.line, t[1]));
+            continue;
+        }
+        let Some(kind) = match_keyword(TYPES, t[2]) else {
+            diags.push(bad(line.line, t[2]));
+            continue;
+        };
+        let p1 = t.get(3).copied().filter(|p| *p != "*");
+        let series_or_value = |scale: f64| -> Option<SeriesOrValue> {
+            let p = p1?;
+            Some(match p.finite_f64() {
+                Ok(v) => SeriesOrValue::Value(v * scale),
+                Err(()) => SeriesOrValue::Series(p.to_string()),
+            })
+        };
+        let condition = match kind {
+            0 => BoundaryCondition::Wall,
+            1 => {
+                let Some(Ok(slope)) = p1.map(|p| p.finite_f64()) else {
+                    diags.push(err(line.line, DiagnosticKind::MissingItems));
+                    continue;
+                };
+                BoundaryCondition::NormalFlow { slope }
+            }
+            // SPECIFIED_STAGE and TS_STAGE are one condition: the
+            // parameter's spelling decides constant against series.
+            2 | 3 => match series_or_value(vlen) {
+                Some(v) => BoundaryCondition::Stage(v),
+                None => {
+                    diags.push(err(line.line, DiagnosticKind::MissingItems));
+                    continue;
+                }
+            },
+            // Likewise SPECIFIED_FLOW and TS_FLOW. Per-metre discharge
+            // converts by the flow factor alone: the metre is a metre in
+            // every unit system (§14.15).
+            4 | 5 => match series_or_value(flow) {
+                Some(v) => BoundaryCondition::Flow(v),
+                None => {
+                    diags.push(err(line.line, DiagnosticKind::MissingItems));
+                    continue;
+                }
+            },
+            _ => {
+                let Some(curve) = p1 else {
+                    diags.push(err(line.line, DiagnosticKind::MissingItems));
+                    continue;
+                };
+                BoundaryCondition::RatingCurve {
+                    curve: curve.to_string(),
+                }
+            }
+        };
+        // Token 4 is the reserved PARAM_2 placeholder; the group can only
+        // follow it (§14.15).
+        let group = t.get(5).copied().filter(|g| *g != "*").map(str::to_string);
+        out.push(BoundaryRow {
+            cell,
+            edge,
+            condition,
+            group,
+        });
+    }
+}
+
+fn parse_conveyance(
+    lines: &[TokenLine<'_>],
+    out: &mut Vec<ConveyanceRow>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 3 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let (Ok(from), Ok(to)) = (t[0].parse::<u32>(), t[1].parse::<u32>()) else {
+            diags.push(bad(line.line, t[0]));
+            continue;
+        };
+        let Ok(factor) = t[2].finite_f64() else {
+            diags.push(bad(line.line, t[2]));
+            continue;
+        };
+        out.push(ConveyanceRow { from, to, factor });
+    }
+}
+
+fn parse_mesh_file(lines: &[TokenLine<'_>], out: &mut Option<String>, diags: &mut Vec<Diagnostic>) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 2 || !t[0].eq_ignore_ascii_case("FILE") {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        // §14.15: only the first FILE line is honoured.
+        if out.is_none() {
+            *out = Some(t[1].to_string());
+        }
+    }
+}
+
+fn parse_options(lines: &[TokenLine<'_>], opts: &mut OverlandOptions, diags: &mut Vec<Diagnostic>) {
+    for line in lines {
+        let t = &line.tokens;
+        if t.len() < 2 {
+            diags.push(err(line.line, DiagnosticKind::MissingItems));
+            continue;
+        }
+        let key = t[0].to_ascii_uppercase();
+        let value = t[1];
+        if RETIRED_KEYS.contains(&key.as_str()) {
+            diags.push(err(
+                line.line,
+                DiagnosticKind::RetiredOverlandOption { key: key.clone() },
+            ));
+            continue;
+        }
+        let mut num = |lo: f64, hi: f64| -> Option<f64> {
+            match value.finite_f64() {
+                Ok(v) if (lo..=hi).contains(&v) => Some(v),
+                _ => {
+                    diags.push(bad(line.line, value));
+                    None
+                }
+            }
+        };
+        let yes = |v: &str| matches!(v.to_ascii_uppercase().as_str(), "YES" | "ON" | "TRUE" | "1");
+        match key.as_str() {
+            "INTEGRATOR" => {
+                if !value.eq_ignore_ascii_case("EXPLICIT") {
+                    diags.push(err(
+                        line.line,
+                        DiagnosticKind::RetiredOverlandOption { key },
+                    ));
+                }
+            }
+            "CFL_NUMBER" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, 1.0) {
+                    opts.cfl_number = v;
+                }
+            }
+            "MAX_TIMESTEP" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, f64::MAX) {
+                    opts.max_timestep = v;
+                }
+            }
+            "THETA" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, 1.0) {
+                    opts.theta = v;
+                }
+            }
+            "FROUDE_MAX" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, f64::MAX) {
+                    opts.froude_max = v;
+                }
+            }
+            "LTS_TIERS" => match value.parse::<u32>() {
+                Ok(v @ 1..=8) => opts.lts_tiers = v,
+                _ => diags.push(bad(line.line, value)),
+            },
+            "H_MOVE" => {
+                if let Some(v) = num(0.0, f64::MAX) {
+                    opts.h_move = v;
+                }
+            }
+            "DRY_DEPTH" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, f64::MAX) {
+                    opts.dry_depth = v;
+                }
+            }
+            "CELL_CLOSURE" => match value.to_ascii_uppercase().as_str() {
+                "FLAT" => opts.cell_closure = CellClosure::Flat,
+                "VFR" => opts.cell_closure = CellClosure::Vfr,
+                _ => diags.push(bad(line.line, value)),
+            },
+            "FACE_RECONSTRUCTION" => match value.to_ascii_uppercase().as_str() {
+                "MEAN" => opts.face_reconstruction = FaceReconstruction::Mean,
+                "VFR_FACE" => opts.face_reconstruction = FaceReconstruction::VfrFace,
+                _ => diags.push(bad(line.line, value)),
+            },
+            "VFR_MIN_WET_FRAC" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, 0.5) {
+                    opts.vfr_min_wet_frac = v;
+                }
+            }
+            "ADVECTION" => opts.advection = yes(value),
+            "RAINFALL_MODE" => match value.to_ascii_uppercase().as_str() {
+                "NATURAL_NEIGHBOUR" | "NATURAL_NEIGHBOR" => {
+                    opts.rainfall_mode = RainfallMode::NaturalNeighbour;
+                }
+                "SYSTEM" => opts.rainfall_mode = RainfallMode::System,
+                "NONE" => opts.rainfall_mode = RainfallMode::None,
+                _ => diags.push(bad(line.line, value)),
+            },
+            "COUPLING_AREA" => match value.to_ascii_uppercase().as_str() {
+                "AUTO" => opts.coupling_area_auto = true,
+                "DEFAULT" => opts.coupling_area_auto = false,
+                _ => diags.push(bad(line.line, value)),
+            },
+            "COUPLING_CD" => {
+                if let Some(v) = num(f64::MIN_POSITIVE, f64::MAX) {
+                    opts.coupling_cd = v;
+                }
+            }
+            "COUPLING_SYNC" => {
+                if let Some(v) = num(0.0, f64::MAX) {
+                    opts.coupling_sync = v;
+                }
+            }
+            "REPORT_2D" => opts.report_2d = yes(value),
+            "OUTPUT_FILE" => opts.output_file = Some(value.to_string()),
+            // §14.15: an unknown key warns and is ignored — the
+            // predecessor's vocabulary churns, and a file is never
+            // refused over an option.
+            _ => diags.push(err(
+                line.line,
+                DiagnosticKind::UnknownOverlandOption { key },
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::objects::parse_network;
+
+    fn model(extra: &str) -> String {
+        format!(
+            "[OPTIONS]\nFLOW_UNITS CMS\n\n{extra}\n[JUNCTIONS]\nJ1 10 4 0 0 0\n\
+             [OUTFALLS]\nO1 9 FREE NO\n[CONDUITS]\nC1 J1 O1 100 0.013 0 0 0 0\n\
+             [XSECTIONS]\nC1 CIRCULAR 1 0 0 0 1\n"
+        )
+    }
+
+    const MESH: &str = "[2D_VERTICES]\n0 0 10.0\n1 0 10.2 VA\n1 1 10.4\n0 1 10.6\n\
+                        [2D_TRIANGLES]\n0 1 2 0.02\n0 2 3 0.03 0.05 TB\n";
+
+    #[test]
+    fn a_mesh_parses_with_indices_in_file_order() {
+        let (net, diags) = parse_network(&model(MESH));
+        assert!(diags.iter().all(|d| !d.kind.is_error()), "{diags:?}");
+        let mesh = net.overland.expect("mesh present");
+        assert_eq!(mesh.verts.len(), 4);
+        assert_eq!(mesh.verts[1].tag.as_deref(), Some("VA"));
+        assert_eq!(mesh.cells.len(), 2);
+        assert_eq!(mesh.cells[1].v, [0, 2, 3]);
+        assert_eq!(mesh.cells[1].h0, 0.05);
+        assert_eq!(mesh.cells[1].tag.as_deref(), Some("TB"));
+    }
+
+    /// §14.15: the fifth triangle column is a depth when numeric and a
+    /// tag otherwise.
+    #[test]
+    fn the_fifth_triangle_column_disambiguates_by_spelling() {
+        let extra = "[2D_VERTICES]\n0 0 1\n1 0 1\n0 1 1\n\
+                     [2D_TRIANGLES]\n0 1 2 0.02 LEGACY_TAG\n";
+        let (net, _) = parse_network(&model(extra));
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.cells[0].h0, 0.0);
+        assert_eq!(mesh.cells[0].tag.as_deref(), Some("LEGACY_TAG"));
+    }
+
+    /// A US-unit model scales lengths and areas; the SI header bypasses
+    /// exactly that scaling and cannot be revoked.
+    #[test]
+    fn display_units_scale_unless_the_header_asserts_si() {
+        let us = "[OPTIONS]\nFLOW_UNITS CFS\n\n[2D_VERTICES]\n0 0 100\n3 0 100\n0 3 100\n\
+                  [2D_TRIANGLES]\n0 1 2 0.02 0.5\n\
+                  [2D_VERTEX_NODE_MAP]\n0 J1 0.6 2.0\n\
+                  [JUNCTIONS]\nJ1 10 4 0 0 0\n";
+        let (net, _) = parse_network(us);
+        let mesh = net.overland.expect("mesh");
+        let ft = 0.3048;
+        assert!((mesh.verts[1].x - 3.0 * ft).abs() < 1e-12);
+        assert!((mesh.cells[0].h0 - 0.5 * ft).abs() < 1e-12);
+        assert!((mesh.vertex_couplings[0].area - 2.0 * ft * ft).abs() < 1e-12);
+
+        let si = format!(";; UNITS: SI (m)\n{us}");
+        let (net, _) = parse_network(&si);
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.verts[1].x, 3.0);
+        assert_eq!(mesh.cells[0].h0, 0.5);
+        assert_eq!(mesh.vertex_couplings[0].area, 2.0);
+        assert!(mesh.units_si);
+    }
+
+    /// §14.15 addressing: numeric index first, tag fallback — including
+    /// a purely numeric tag shadowed by no in-range index.
+    #[test]
+    fn couplings_resolve_by_index_then_tag() {
+        let extra = format!(
+            "{MESH}[2D_VERTEX_NODE_MAP]\nVA J1\n\
+             [2D_TRIANGLE_NODE_MAP]\nTB J1 0.7\n1 O1\n"
+        );
+        let (net, diags) = parse_network(&model(&extra));
+        assert!(diags.iter().all(|d| !d.kind.is_error()), "{diags:?}");
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.vertex_couplings.len(), 1);
+        assert_eq!(mesh.vertex_couplings[0].mesh_index, 1, "tag VA is vertex 1");
+        assert_eq!(mesh.vertex_couplings[0].cd, 0.65, "default coefficient");
+        assert!(!mesh.vertex_couplings[0].area_authored);
+        // Triangle rows accumulate; tag TB is cell 1, and the numeric row
+        // addresses the same cell — both rows stand.
+        assert_eq!(mesh.cell_couplings.len(), 2);
+        assert_eq!(mesh.cell_couplings[0].mesh_index, 1);
+        assert_eq!(mesh.cell_couplings[0].cd, 0.7);
+        assert_eq!(mesh.cell_couplings[1].mesh_index, 1);
+    }
+
+    /// One coupling per vertex: a later row replaces the earlier.
+    #[test]
+    fn a_later_vertex_coupling_replaces_the_earlier() {
+        let extra = format!("{MESH}[2D_VERTEX_NODE_MAP]\n0 J1 0.5\n0 O1 0.9\n");
+        let (net, _) = parse_network(&model(&extra));
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.vertex_couplings.len(), 1);
+        assert_eq!(mesh.vertex_couplings[0].node, "O1");
+        assert_eq!(mesh.vertex_couplings[0].cd, 0.9);
+    }
+
+    #[test]
+    fn boundary_rows_carry_their_five_conditions() {
+        let extra = format!(
+            "{MESH}[2D_BOUNDARY_CONDITIONS]\n\
+             0 0 WALL\n\
+             0 2 NORMAL_FLOW 0.01\n\
+             1 0 SPECIFIED_STAGE 10.5\n\
+             1 1 TS_STAGE TIDE * G1\n\
+             0 1 SPECIFIED_FLOW 0.2\n\
+             1 2 RATING_CURVE RC1\n"
+        );
+        let (net, diags) = parse_network(&model(&extra));
+        assert!(diags.iter().all(|d| !d.kind.is_error()), "{diags:?}");
+        let b = &net.overland.expect("mesh").boundaries;
+        assert_eq!(b.len(), 6);
+        assert_eq!(b[0].condition, BoundaryCondition::Wall);
+        assert_eq!(
+            b[1].condition,
+            BoundaryCondition::NormalFlow { slope: 0.01 }
+        );
+        assert_eq!(
+            b[2].condition,
+            BoundaryCondition::Stage(SeriesOrValue::Value(10.5))
+        );
+        assert_eq!(
+            b[3].condition,
+            BoundaryCondition::Stage(SeriesOrValue::Series("TIDE".into()))
+        );
+        assert_eq!(b[3].group.as_deref(), Some("G1"));
+        assert_eq!(
+            b[4].condition,
+            BoundaryCondition::Flow(SeriesOrValue::Value(0.2))
+        );
+        assert_eq!(
+            b[5].condition,
+            BoundaryCondition::RatingCurve {
+                curve: "RC1".into()
+            }
+        );
+    }
+
+    /// Options apply; retired and unknown keys warn without refusing.
+    #[test]
+    fn options_apply_and_retired_keys_only_warn() {
+        let extra = format!(
+            "{MESH}[2D_OPTIONS]\n\
+             CFL_NUMBER 0.5\nTHETA 1.0\nCELL_CLOSURE VFR\n\
+             RAINFALL_MODE NONE\nCOUPLING_CD 0.8\nLTS_TIERS 1\n\
+             MIN_TIMESTEP 0.01\nSOME_FUTURE_KEY 7\n"
+        );
+        let (net, diags) = parse_network(&model(&extra));
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.options.cfl_number, 0.5);
+        assert_eq!(mesh.options.theta, 1.0);
+        assert_eq!(mesh.options.cell_closure, CellClosure::Vfr);
+        assert_eq!(mesh.options.rainfall_mode, RainfallMode::None);
+        assert_eq!(mesh.options.coupling_cd, 0.8);
+        assert_eq!(mesh.options.lts_tiers, 1);
+        let retired = diags
+            .iter()
+            .filter(|d| matches!(&d.kind, DiagnosticKind::RetiredOverlandOption { .. }))
+            .count();
+        let unknown = diags
+            .iter()
+            .filter(|d| matches!(&d.kind, DiagnosticKind::UnknownOverlandOption { .. }))
+            .count();
+        assert_eq!(retired, 1);
+        assert_eq!(unknown, 1);
+        assert!(diags.iter().all(|d| !d.kind.is_error()));
+    }
+
+    /// `COUPLING_CD` is honoured as the default for rows without their
+    /// own coefficient — the correspondence deviation §14.15 records.
+    #[test]
+    fn the_global_coupling_cd_serves_rows_without_their_own() {
+        let extra = format!("{MESH}[2D_OPTIONS]\nCOUPLING_CD 0.8\n[2D_VERTEX_NODE_MAP]\n0 J1\n");
+        let (net, _) = parse_network(&model(&extra));
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.vertex_couplings[0].cd, 0.8);
+    }
+
+    #[test]
+    fn only_the_first_mesh_file_line_is_honoured() {
+        let extra = "[2D_MESH_FILE]\nFILE terrain.2dm\nFILE other.2dm\n";
+        let (net, _) = parse_network(&model(extra));
+        let mesh = net.overland.expect("mesh");
+        assert_eq!(mesh.mesh_file.as_deref(), Some("terrain.2dm"));
+    }
+
+    #[test]
+    fn a_model_without_mesh_sections_carries_no_mesh() {
+        let (net, _) = parse_network(&model(""));
+        assert!(net.overland.is_none());
+    }
+}

--- a/crates/engine-uds/src/io/overland.rs
+++ b/crates/engine-uds/src/io/overland.rs
@@ -76,6 +76,93 @@ pub(crate) fn units_header_si(text: &str) -> bool {
     si
 }
 
+/// §14.15's external mesh file: re-parse the mesh from the model's own
+/// 2D sections continued by the external file's, under the combined SI
+/// header. The model text's non-2D lines are blanked rather than
+/// removed, so inline diagnostics keep their line numbers; the inline
+/// 2D sections were already parsed once by the ordinary pass, so their
+/// warnings may repeat here — a cosmetic cost the combined numbering is
+/// worth.
+pub(crate) fn reparse_with_external(
+    input: &str,
+    external: &str,
+    options: &super::options::AnalysisOptions,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<OverlandMesh> {
+    let inline_2d = two_d_lines_only(input);
+    let s1 = super::survey::survey(&inline_2d);
+    let s2 = super::survey::survey(external);
+    let mut sections: Vec<(Section, Vec<TokenLine<'_>>)> = Vec::new();
+    for (sec, lines) in s1.sections.iter().chain(s2.sections.iter()) {
+        if is_two_d(*sec) && *sec != Section::TwoDMeshFile {
+            sections.push((*sec, lines.clone()));
+        }
+    }
+    let units_si = units_header_si(input) || units_header_si(external);
+    let cv = super::objects::UnitConverter::new(options.flow_units, options.link_offsets);
+    let mut mesh = parse_overland(&sections, units_si, cv.len, cv.flow, diags)?;
+    // The declaration survives for writers and refusals even though the
+    // combined parse no longer sees the section.
+    mesh.mesh_file = two_d_mesh_file_name(input);
+    Some(mesh)
+}
+
+fn is_two_d(sec: Section) -> bool {
+    matches!(
+        sec,
+        Section::TwoDOptions
+            | Section::TwoDVertices
+            | Section::TwoDTriangles
+            | Section::TwoDInitialVelocity
+            | Section::TwoDVertexNodeMap
+            | Section::TwoDTriangleNodeMap
+            | Section::TwoDBoundaryConditions
+            | Section::TwoDEdgeConveyance
+            | Section::TwoDMeshFile
+    )
+}
+
+/// The model text with every line outside a 2D section blanked, so a
+/// re-survey sees only the mesh and every diagnostic keeps its line.
+fn two_d_lines_only(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut keep = false;
+    for line in text.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            keep = t.to_ascii_uppercase().starts_with("[2D_");
+        }
+        if keep {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn two_d_mesh_file_name(text: &str) -> Option<String> {
+    let mut in_section = false;
+    for line in text.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_section = t.to_ascii_uppercase().starts_with("[2D_MESH_FILE");
+            continue;
+        }
+        if in_section {
+            let mut tokens = t.split_whitespace();
+            if tokens
+                .next()
+                .is_some_and(|w| w.eq_ignore_ascii_case("FILE"))
+            {
+                if let Some(name) = tokens.next() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Parse every §14.15 section into the §15.2 mesh model. `None` when the
 /// model carries no overland input at all. `len` is the display-length
 /// factor (m per file length unit) and `flow` the display-flow factor
@@ -126,15 +213,16 @@ pub(crate) fn parse_overland(
     for (sec, lines) in sections {
         match sec {
             Section::TwoDInitialVelocity => {
-                parse_init_velocity(lines, mesh.cells.len(), &mut mesh.init_velocity, diags);
+                parse_init_velocity(lines, &mut mesh.init_velocity, diags);
             }
             Section::TwoDVertexNodeMap => {
-                parse_couplings(lines, Addr::Vertex, &mesh, vlen, diags)
-                    .into_iter()
-                    .for_each(|row| upsert_vertex_coupling(&mut mesh.vertex_couplings, row));
+                let cd = mesh.options.coupling_cd;
+                let rows = parse_couplings(lines, cd, vlen, diags);
+                mesh.vertex_couplings.extend(rows);
             }
             Section::TwoDTriangleNodeMap => {
-                let rows = parse_couplings(lines, Addr::Cell, &mesh, vlen, diags);
+                let cd = mesh.options.coupling_cd;
+                let rows = parse_couplings(lines, cd, vlen, diags);
                 mesh.cell_couplings.extend(rows);
             }
             Section::TwoDBoundaryConditions => {
@@ -147,14 +235,6 @@ pub(crate) fn parse_overland(
         }
     }
     Some(mesh)
-}
-
-/// §14.15: one coupling per vertex — a later row replaces the earlier.
-fn upsert_vertex_coupling(rows: &mut Vec<CouplingRow>, row: CouplingRow) {
-    match rows.iter_mut().find(|r| r.mesh_index == row.mesh_index) {
-        Some(existing) => *existing = row,
-        None => rows.push(row),
-    }
 }
 
 fn parse_vertices(
@@ -231,7 +311,6 @@ fn parse_cells(
 
 fn parse_init_velocity(
     lines: &[TokenLine<'_>],
-    n_cells: usize,
     out: &mut Vec<InitVelocityRow>,
     diags: &mut Vec<Diagnostic>,
 ) {
@@ -241,14 +320,12 @@ fn parse_init_velocity(
             diags.push(err(line.line, DiagnosticKind::MissingItems));
             continue;
         }
+        // Range is a whole-mesh question — an external file may still
+        // add cells — so it belongs to Topology::build, not here.
         let Ok(cell) = t[0].parse::<u32>() else {
             diags.push(bad(line.line, t[0]));
             continue;
         };
-        if cell as usize >= n_cells {
-            diags.push(bad(line.line, t[0]));
-            continue;
-        }
         let (Ok(u), Ok(v)) = (t[1].finite_f64(), t[2].finite_f64()) else {
             diags.push(bad(line.line, t[1]));
             continue;
@@ -257,36 +334,9 @@ fn parse_init_velocity(
     }
 }
 
-/// Which list a coupling row addresses.
-enum Addr {
-    Vertex,
-    Cell,
-}
-
-/// §14.15's addressing rule: the first token is an index where numeric
-/// and in range, else a tag — so purely numeric tags still resolve.
-fn resolve_addr(token: &str, addr: &Addr, mesh: &OverlandMesh) -> Option<u32> {
-    let count = match addr {
-        Addr::Vertex => mesh.verts.len(),
-        Addr::Cell => mesh.cells.len(),
-    };
-    if let Ok(i) = token.parse::<u32>() {
-        if (i as usize) < count {
-            return Some(i);
-        }
-    }
-    let by_tag = |tag: &Option<String>| tag.as_deref() == Some(token);
-    match addr {
-        Addr::Vertex => mesh.verts.iter().position(|v| by_tag(&v.tag)),
-        Addr::Cell => mesh.cells.iter().position(|c| by_tag(&c.tag)),
-    }
-    .map(|i| i as u32)
-}
-
 fn parse_couplings(
     lines: &[TokenLine<'_>],
-    addr: Addr,
-    mesh: &OverlandMesh,
+    default_cd: f64,
     vlen: f64,
     diags: &mut Vec<Diagnostic>,
 ) -> Vec<CouplingRow> {
@@ -297,12 +347,8 @@ fn parse_couplings(
             diags.push(err(line.line, DiagnosticKind::MissingItems));
             continue;
         }
-        let Some(mesh_index) = resolve_addr(t[0], &addr, mesh) else {
-            diags.push(bad(line.line, t[0]));
-            continue;
-        };
         let cd = match t.get(2) {
-            None => mesh.options.coupling_cd,
+            None => default_cd,
             Some(tok) => match tok.finite_f64() {
                 Ok(v) => v,
                 Err(()) => {
@@ -322,7 +368,7 @@ fn parse_couplings(
             },
         };
         rows.push(CouplingRow {
-            mesh_index,
+            address: t[0].to_string(),
             node: t[1].to_string(),
             cd,
             area,
@@ -647,10 +693,11 @@ mod tests {
         assert!(mesh.units_si);
     }
 
-    /// §14.15 addressing: numeric index first, tag fallback — including
-    /// a purely numeric tag shadowed by no in-range index.
+    /// §14.15 addressing is derivation: rows carry their authored
+    /// address, and resolution — numeric index first, tag fallback —
+    /// happens against the full mesh.
     #[test]
-    fn couplings_resolve_by_index_then_tag() {
+    fn couplings_carry_addresses_and_resolve_at_build() {
         let extra = format!(
             "{MESH}[2D_VERTEX_NODE_MAP]\nVA J1\n\
              [2D_TRIANGLE_NODE_MAP]\nTB J1 0.7\n1 O1\n"
@@ -659,26 +706,25 @@ mod tests {
         assert!(diags.iter().all(|d| !d.kind.is_error()), "{diags:?}");
         let mesh = net.overland.expect("mesh");
         assert_eq!(mesh.vertex_couplings.len(), 1);
-        assert_eq!(mesh.vertex_couplings[0].mesh_index, 1, "tag VA is vertex 1");
+        assert_eq!(mesh.vertex_couplings[0].address, "VA");
+        assert_eq!(mesh.resolve_vertex("VA"), Some(1), "tag VA is vertex 1");
         assert_eq!(mesh.vertex_couplings[0].cd, 0.65, "default coefficient");
         assert!(!mesh.vertex_couplings[0].area_authored);
-        // Triangle rows accumulate; tag TB is cell 1, and the numeric row
-        // addresses the same cell — both rows stand.
+        // Triangle rows accumulate; tag TB and the numeric row address
+        // the same cell — both rows stand.
         assert_eq!(mesh.cell_couplings.len(), 2);
-        assert_eq!(mesh.cell_couplings[0].mesh_index, 1);
+        assert_eq!(mesh.resolve_cell("TB"), Some(1));
         assert_eq!(mesh.cell_couplings[0].cd, 0.7);
-        assert_eq!(mesh.cell_couplings[1].mesh_index, 1);
-    }
-
-    /// One coupling per vertex: a later row replaces the earlier.
-    #[test]
-    fn a_later_vertex_coupling_replaces_the_earlier() {
-        let extra = format!("{MESH}[2D_VERTEX_NODE_MAP]\n0 J1 0.5\n0 O1 0.9\n");
-        let (net, _) = parse_network(&model(&extra));
-        let mesh = net.overland.expect("mesh");
-        assert_eq!(mesh.vertex_couplings.len(), 1);
-        assert_eq!(mesh.vertex_couplings[0].node, "O1");
-        assert_eq!(mesh.vertex_couplings[0].cd, 0.9);
+        assert_eq!(mesh.resolve_cell(&mesh.cell_couplings[1].address), Some(1));
+        // The full mesh validates: every address is known.
+        assert!(crate::overland::Topology::build(&mesh).is_ok());
+        // An address matching nothing is a named build defect.
+        let mut broken = mesh.clone();
+        broken.vertex_couplings[0].address = "NOWHERE".into();
+        let errors = crate::overland::Topology::build(&broken).expect_err("bad address");
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, crate::overland::MeshError::UnknownAddress { .. })));
     }
 
     #[test]
@@ -768,6 +814,60 @@ mod tests {
         let (net, _) = parse_network(&model(extra));
         let mesh = net.overland.expect("mesh");
         assert_eq!(mesh.mesh_file.as_deref(), Some("terrain.2dm"));
+    }
+
+    /// §14.15 export: a written mesh re-imports as the same mesh — the
+    /// SI header makes the round trip unit-exact, and the always-written
+    /// depth keeps a tagged cell's fifth column unambiguous.
+    #[test]
+    fn a_written_mesh_reimports_identically() {
+        let extra = format!(
+            "{MESH}[2D_OPTIONS]
+CFL_NUMBER 0.5
+CELL_CLOSURE VFR
+COUPLING_CD 0.8
+             [2D_INITIAL_VELOCITY]
+0 0.1 -0.2
+             [2D_VERTEX_NODE_MAP]
+0 J1
+             [2D_TRIANGLE_NODE_MAP]
+TB O1 0.7 2.5
+             [2D_BOUNDARY_CONDITIONS]
+0 0 WALL
+1 1 TS_STAGE TIDE * G1
+             [2D_EDGE_CONVEYANCE]
+0 2 0.3
+"
+        );
+        let (net, _) = parse_network(&model(&extra));
+        let text = crate::io::inp_writer::write_inp(&net).expect("writable");
+        let (net2, diags) = parse_network(&text);
+        assert!(diags.iter().all(|d| !d.kind.is_error()), "{diags:?}");
+        let (a, b) = (net.overland.expect("mesh"), net2.overland.expect("mesh"));
+        // The reimport asserts SI, whatever the original said.
+        assert!(b.units_si);
+        assert_eq!(a.verts, b.verts);
+        assert_eq!(a.cells, b.cells);
+        assert_eq!(a.init_velocity, b.init_velocity);
+        assert_eq!(a.vertex_couplings, b.vertex_couplings);
+        assert_eq!(a.cell_couplings, b.cell_couplings);
+        assert_eq!(a.boundaries, b.boundaries);
+        assert_eq!(a.conveyance, b.conveyance);
+        assert_eq!(a.options, b.options);
+    }
+
+    /// §15.7: `[SYMBOLS]` feeds gauge positions exactly when a mesh is
+    /// present, in the mesh's own unit handling.
+    #[test]
+    fn symbols_position_gauges_only_when_a_mesh_is_present() {
+        let gage = "[RAINGAGES]\nG1 INTENSITY 1:00 1.0 TIMESERIES TS1\n\
+                    [TIMESERIES]\nTS1 0:00 0\n[SYMBOLS]\nG1 300 400\n";
+        let with_mesh = format!("{MESH}{gage}");
+        let (net, _) = parse_network(&model(&with_mesh));
+        assert_eq!(net.gages[0].position, Some((300.0, 400.0)));
+
+        let (net, _) = parse_network(&model(gage));
+        assert_eq!(net.gages[0].position, None, "no mesh, no exception");
     }
 
     #[test]

--- a/crates/engine-uds/src/io/overland_out.rs
+++ b/crates/engine-uds/src/io/overland_out.rs
@@ -1,0 +1,180 @@
+//! §14.16: the overland results stream — this engine's own framed
+//! sidecar layout, written at the §14.9 reporting instants.
+//!
+//! Everything is little-endian and SI. The clock, geometry and ledger
+//! are eight-byte floats; per-cell record values are four-byte floats,
+//! the resolution every §14.9 reported result already has.
+
+use std::io::{self, Write};
+
+use crate::overland::marcher::Marcher;
+use crate::overland::OverlandMesh;
+
+/// §14.16 leading and closing magic.
+pub const MAGIC: u32 = 1_214_727_218;
+/// §14.16 format version.
+pub const VERSION: u32 = 1;
+
+/// One §15.8 ledger row, cumulative since the start of the run (m³).
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct LedgerRow {
+    pub storage: f64,
+    pub rain_in: f64,
+    pub evap_out: f64,
+    pub junction_out: f64,
+    pub junction_in: f64,
+    pub outfall_in: f64,
+    pub outfall_out: f64,
+    pub boundary_in: f64,
+    pub boundary_out: f64,
+    pub error: f64,
+}
+
+impl LedgerRow {
+    /// Read the row off the live marcher.
+    pub fn of(m: &Marcher) -> LedgerRow {
+        LedgerRow {
+            storage: m.storage(),
+            rain_in: m.rain_in,
+            evap_out: m.evap_out,
+            junction_out: m.coupling_out,
+            junction_in: m.coupling_in,
+            outfall_in: m.outfall_in,
+            outfall_out: m.outfall_out,
+            boundary_in: m.boundary_in,
+            boundary_out: m.boundary_out,
+            error: m.ledger_error(),
+        }
+    }
+
+    pub(crate) fn to_array(self) -> [f64; 10] {
+        [
+            self.storage,
+            self.rain_in,
+            self.evap_out,
+            self.junction_out,
+            self.junction_in,
+            self.outfall_in,
+            self.outfall_out,
+            self.boundary_in,
+            self.boundary_out,
+            self.error,
+        ]
+    }
+
+    pub(crate) fn from_array(a: [f64; 10]) -> LedgerRow {
+        LedgerRow {
+            storage: a[0],
+            rain_in: a[1],
+            evap_out: a[2],
+            junction_out: a[3],
+            junction_in: a[4],
+            outfall_in: a[5],
+            outfall_out: a[6],
+            boundary_in: a[7],
+            boundary_out: a[8],
+            error: a[9],
+        }
+    }
+}
+
+/// The size of one record (bytes) for `nc` cells and `np` points.
+pub(crate) fn record_len(nc: usize, np: usize) -> u64 {
+    8 + 4 * 4 * nc as u64 + 4 * np as u64 + 8 * 10
+}
+
+/// The header's size (bytes) for `nv` vertices, `nc` cells, `np`
+/// points.
+pub(crate) fn header_len(nv: usize, nc: usize, np: usize) -> u64 {
+    4 * 5 + 8 * 3 + 24 * nv as u64 + 12 * nc as u64 + 4 * np as u64
+}
+
+/// §14.16: the stream, generic over its sink exactly as the §14.9
+/// stream is.
+pub struct OverlandStream<W: Write> {
+    w: W,
+    nc: usize,
+    np: usize,
+    periods: i32,
+}
+
+impl<W: Write> OverlandStream<W> {
+    /// Write the header: identity, counts, the reporting clock, and
+    /// the mesh geometry a viewer renders without the model.
+    pub fn begin(
+        mut sink: W,
+        mesh: &OverlandMesh,
+        marcher: &Marcher,
+        start_epoch: f64,
+        report_step: f64,
+        first_report_t: f64,
+    ) -> io::Result<Self> {
+        let (nv, nc) = (mesh.verts.len(), mesh.cells.len());
+        let np = marcher.coupling_points().len();
+        sink.write_all(&MAGIC.to_le_bytes())?;
+        sink.write_all(&VERSION.to_le_bytes())?;
+        for n in [nv as u32, nc as u32, np as u32] {
+            sink.write_all(&n.to_le_bytes())?;
+        }
+        for f in [start_epoch, report_step, first_report_t] {
+            sink.write_all(&f.to_le_bytes())?;
+        }
+        for v in &mesh.verts {
+            for f in [v.x, v.y, v.z] {
+                sink.write_all(&f.to_le_bytes())?;
+            }
+        }
+        for c in &mesh.cells {
+            for i in c.v {
+                sink.write_all(&i.to_le_bytes())?;
+            }
+        }
+        for cp in marcher.coupling_points() {
+            sink.write_all(&cp.cell.to_le_bytes())?;
+        }
+        Ok(OverlandStream {
+            w: sink,
+            nc,
+            np,
+            periods: 0,
+        })
+    }
+
+    /// Append one reporting instant: run time, per-cell depth, surface
+    /// elevation and velocity, per-point exchange rate, and the §15.8
+    /// ledger.
+    pub fn append(&mut self, t: f64, marcher: &Marcher, exchange_rate: &[f64]) -> io::Result<()> {
+        debug_assert_eq!(exchange_rate.len(), self.np);
+        self.w.write_all(&t.to_le_bytes())?;
+        let dry = marcher.dry_depth();
+        for ci in 0..self.nc {
+            let h = marcher.depth[ci];
+            let (u, v) = if h > dry {
+                let (qx, qy) = marcher.cell_velocity_proxy(ci);
+                ((qx / h) as f32, (qy / h) as f32)
+            } else {
+                (0.0, 0.0)
+            };
+            for f in [h as f32, marcher.eta[ci] as f32, u, v] {
+                self.w.write_all(&f.to_le_bytes())?;
+            }
+        }
+        for q in exchange_rate {
+            self.w.write_all(&(*q as f32).to_le_bytes())?;
+        }
+        for f in LedgerRow::of(marcher).to_array() {
+            self.w.write_all(&f.to_le_bytes())?;
+        }
+        self.periods += 1;
+        Ok(())
+    }
+
+    /// Write the epilog. A file without it is a run that did not
+    /// finish, and the reader says so.
+    pub fn finish(mut self) -> io::Result<W> {
+        self.w.write_all(&self.periods.to_le_bytes())?;
+        self.w.write_all(&MAGIC.to_le_bytes())?;
+        self.w.flush()?;
+        Ok(self.w)
+    }
+}

--- a/crates/engine-uds/src/io/rpt_writer.rs
+++ b/crates/engine-uds/src/io/rpt_writer.rs
@@ -350,8 +350,28 @@ fn link_kind(l: &crate::model::Link) -> &'static str {
 }
 
 /// The inputs the report draws on, gathered by the session.
+/// §14.9's overland additions, present only when a run served a mesh
+/// (§15): the §15.8 ledger, the §15.8 delivered pair on the network
+/// side, and the §15.4.4 march counts.
+#[derive(Debug, Clone)]
+pub struct OverlandRpt {
+    /// The §15.8 ledger, cumulative over the run (m³).
+    pub ledger: crate::io::overland_out::LedgerRow,
+    /// Opening surface storage (m³).
+    pub initial_storage: f64,
+    /// Exchange as delivered to the network ledger (m³): surface
+    /// drainage in, surface spill drawn back out.
+    pub delivered_in: f64,
+    pub delivered_out: f64,
+    /// (base substeps, macro cycles, rebuilds, min base step s,
+    /// average base step s, peak active cells).
+    pub march: (u64, u64, u64, f64, f64, usize),
+}
+
 pub struct ReportInputs<'a> {
     pub net: &'a Network,
+    /// The §15 overland additions, when a mesh was served.
+    pub overland: Option<OverlandRpt>,
     /// The §11.1 surface ledger parts, when a surface exists:
     /// (precipitation, run-on, evaporation, infiltration, runoff,
     /// ploughed snow, initial storage, final storage, error %).
@@ -427,6 +447,11 @@ pub fn write_rpt(inp: &ReportInputs, w: &mut impl Write) -> io::Result<()> {
         write_continuity(inp, &rv, w)?;
     }
     if rpt.flow_stats {
+        // §14.9: the overland time-step summary sits between the
+        // continuity balances and the diagnostics.
+        if let Some(ov) = &inp.overland {
+            write_overland_step_summary(ov, w)?;
+        }
         write_diagnostics(inp, w)?;
         write_step_summary(inp, w)?;
     }
@@ -676,7 +701,15 @@ fn write_continuity(inp: &ReportInputs, rv: &Rv, w: &mut impl Write) -> io::Resu
         line(w, "Groundwater Inflow", &row(gw))?;
         line(w, "RDII Inflow", &row(rdii))?;
         line(w, "External Inflow", &row(ext))?;
+        // §15.8: the exchange is its own named pair, never folded into
+        // the external terms.
+        if let Some(ov) = &inp.overland {
+            line(w, "Surface Drainage", &row(ov.delivered_in))?;
+        }
         line(w, "External Outflow", &row(out))?;
+        if let Some(ov) = &inp.overland {
+            line(w, "Surface Spill", &row(ov.delivered_out))?;
+        }
         line(w, "Flooding Loss", &row(flood))?;
         line(w, "Evaporation Loss", &row(evap))?;
         line(w, "Exfiltration Loss", &row(exfil))?;
@@ -722,6 +755,52 @@ fn write_continuity(inp: &ReportInputs, rv: &Rv, w: &mut impl Write) -> io::Resu
         let errs: Vec<f64> = inp.quality.iter().map(|(_, v)| v[11]).collect();
         line(w, "Continuity Error (%)", &errs)?;
     }
+
+    // §14.9: the overland flow continuity balance, for a run that
+    // served a mesh — the §15.8 ledger as volume rows in the house
+    // style of its neighbours.
+    if let Some(ov) = &inp.overland {
+        let l = &ov.ledger;
+        continuity_head(
+            w,
+            "Overland Flow Continuity",
+            &["Volume", "Volume"],
+            &[rv.big_word(), rv.mgal_word()],
+            &[9, 9],
+        )?;
+        let row = |v: f64| [rv.big(v), rv.mgal(v)];
+        line(w, "Initial Surface Storage", &row(ov.initial_storage))?;
+        line(w, "Rainfall", &row(l.rain_in))?;
+        line(w, "Evaporation", &row(l.evap_out))?;
+        line(w, "Junction Drainage", &row(l.junction_out))?;
+        line(w, "Junction Spill", &row(l.junction_in))?;
+        line(w, "Outfall Injection", &row(l.outfall_in))?;
+        line(w, "Outfall Withdrawal", &row(l.outfall_out))?;
+        line(w, "Boundary Inflow", &row(l.boundary_in))?;
+        line(w, "Boundary Outflow", &row(l.boundary_out))?;
+        line(w, "Final Surface Storage", &row(l.storage))?;
+        let inflow = ov.initial_storage + l.rain_in + l.junction_in + l.outfall_in + l.boundary_in;
+        let err = if inflow > 1e-9 {
+            100.0 * l.error / inflow
+        } else {
+            0.0
+        };
+        line(w, "Continuity Error (%)", &[err])?;
+    }
+    Ok(())
+}
+
+/// §14.9: the overland time-step summary — the march's whole-run
+/// counts (§15.4.4).
+fn write_overland_step_summary(ov: &OverlandRpt, w: &mut impl Write) -> io::Result<()> {
+    let (substeps, cycles, rebuilds, min_dt, avg_dt, peak) = ov.march;
+    heading(w, "Overland Time Step Summary")?;
+    writeln!(w, "  Base Substeps               : {substeps:>8}")?;
+    writeln!(w, "  Macro Cycles                : {cycles:>8}")?;
+    writeln!(w, "  Active-Set Rebuilds         : {rebuilds:>8}")?;
+    writeln!(w, "  Minimum Base Step           : {min_dt:>8.4} sec")?;
+    writeln!(w, "  Average Base Step           : {avg_dt:>8.4} sec")?;
+    writeln!(w, "  Peak Active Cells           : {peak:>8}")?;
     Ok(())
 }
 

--- a/crates/engine-uds/src/io/survey.rs
+++ b/crates/engine-uds/src/io/survey.rs
@@ -162,6 +162,19 @@ pub enum DiagnosticKind {
     },
     /// A line with too few items for its section's grammar.
     MissingItems,
+    /// A retired §14.15 overland option: accepted for compatibility,
+    /// governing nothing.
+    RetiredOverlandOption {
+        /// The key as written, upper-cased.
+        key: String,
+    },
+    /// An overland option this vocabulary does not carry (§14.15): the
+    /// predecessor's option set churns, so unknown keys warn and are
+    /// ignored rather than refusing the file.
+    UnknownOverlandOption {
+        /// The key as written, upper-cased.
+        key: String,
+    },
     /// A value token failing its field's grammar or range.
     BadValue {
         /// The offending token.
@@ -203,6 +216,8 @@ impl DiagnosticKind {
                 | DiagnosticKind::CappedValue { .. }
                 | DiagnosticKind::OverriddenDefinition { .. }
                 | DiagnosticKind::ExtraTokensIgnored { .. }
+                | DiagnosticKind::RetiredOverlandOption { .. }
+                | DiagnosticKind::UnknownOverlandOption { .. }
         )
     }
 
@@ -273,6 +288,12 @@ impl std::fmt::Display for DiagnosticKind {
                 write!(f, "{what} {token:?} capped to its accepted range")
             }
             DiagnosticKind::MissingItems => write!(f, "too few items for this section's grammar"),
+            DiagnosticKind::RetiredOverlandOption { key } => {
+                write!(f, "retired 2D option {key} is accepted and governs nothing")
+            }
+            DiagnosticKind::UnknownOverlandOption { key } => {
+                write!(f, "unknown 2D option {key} ignored")
+            }
             DiagnosticKind::BadValue { token } => write!(f, "bad value {token:?}"),
             DiagnosticKind::OverriddenDefinition { what, id } => {
                 write!(f, "later {what} line for {id:?} replaces the earlier one")

--- a/crates/engine-uds/src/lib.rs
+++ b/crates/engine-uds/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hydraulics;
 pub mod hydrology;
 pub mod io;
 pub mod model;
+pub mod overland;
 pub mod report_blocks;
 pub mod simulation;
 pub mod transport;

--- a/crates/engine-uds/src/model/mod.rs
+++ b/crates/engine-uds/src/model/mod.rs
@@ -48,6 +48,8 @@ pub struct Network {
     pub aquifers: Vec<Aquifer>,
     /// Snow pack parameter sets, in registration order.
     pub snowpacks: Vec<Snowpack>,
+    /// The overland surface mesh (§15.2), when the model authors one.
+    pub overland: Option<crate::overland::OverlandMesh>,
     /// Unit-hydrograph groups, in registration order.
     pub unit_hydrographs: Vec<UnitHydrographGroup>,
     /// Sewer-inflow (RDII) assignments at vertices.

--- a/crates/engine-uds/src/model/mod.rs
+++ b/crates/engine-uds/src/model/mod.rs
@@ -622,6 +622,10 @@ pub struct Gage {
     pub catch_factor: f64,
     /// Where the record comes from.
     pub source: GageSource,
+    /// Map position (m, SI), from `[SYMBOLS]` — populated only when the
+    /// model carries an overland mesh, the one recorded exception to
+    /// display metadata's semantics-free rule (§14.5, §15.7).
+    pub position: Option<(f64, f64)>,
 }
 
 /// Precipitation record forms.

--- a/crates/engine-uds/src/model/spec.md
+++ b/crates/engine-uds/src/model/spec.md
@@ -21,6 +21,14 @@ A drainage model describes water and material moving between four compartments:
 - **Conveyance** — the network of channels, pipes, structures, and storage that
   carries water to receiving waters.
 
+A model may additionally carry an **overland surface** (§15): a meshed
+ground surface on which water ponds and conveys in two dimensions,
+exchanging with the conveyance network at mapped points. It is an optional
+refinement of the land-surface compartment for the flooding problem — where
+parcels lump the surface into stores, the mesh resolves it spatially — and
+a model carries either view of any given ground, not both (§15.7 records
+the double-count hazard).
+
 **No compartment is mandatory.** A model may be conveyance alone, driven by
 supplied inflow time series, or surface alone, ending at parcel outlets. Every
 subsystem specification states its behaviour when a compartment it draws from is
@@ -38,9 +46,11 @@ may be assumed about an entity's relationship to the network.
 
 1. **Network elements** — vertices and edges of the conveyance graph. Only
    these have topology.
-2. **Areal entities** — parcels, aquifers, and snow packs. These are simulated,
-   hold state, and are referenced by network elements, but are neither vertices
-   nor edges. A parcel is a surface, not a point or a channel.
+2. **Areal entities** — parcels, aquifers, snow packs, and the overland
+   mesh's cells (§15.2). These are simulated, hold state, and are referenced
+   by network elements, but are neither vertices nor edges. A parcel is a
+   surface, not a point or a channel; a mesh cell is ground, addressed by
+   index rather than identifier.
 3. **Shared definitions** — cross-section profiles, street sections, aquifer
    parameters, snow-pack parameters, unit-hydrograph groups, and control-measure
    designs. Each is defined once and instantiated by reference from many
@@ -235,6 +245,8 @@ The state is small relative to the model's scope:
 | Regulator | Current setting, whether a control placed it there or it opened by its own rule |
 | Sewer inflow | The convolution's memory of the rainfall still draining through each unit hydrograph |
 | Constituent | Accumulated surface mass and ponded mass per parcel, with time since last removal; concentration per vertex and per edge |
+| Overland cell | Stored water volume (§15.3; surface elevation and depth are derived) |
+| Overland face | Unit-width discharge, interior and boundary alike (§15.4) |
 
 Everything else the engine reports — velocities, volumes, flooding, loads — is
 derived from this state, the inputs, and the parameters.

--- a/crates/engine-uds/src/overland/closure.rs
+++ b/crates/engine-uds/src/overland/closure.rs
@@ -1,0 +1,284 @@
+//! §15.3: the stage–storage closures and face-depth reconstructions.
+//!
+//! Everything here is a pure function of a cell's geometry and its mean
+//! depth or stage — the marcher (§15.4) evaluates these, never integrates
+//! them. The VFR relations are Begnudelli & Sanders' planar-bed
+//! stage–storage, regularised by a wet-fraction floor so a drying cell's
+//! closure stays $C^1$ and monotone.
+
+/// Relief below which a cell's bed is flat for every purpose: the VFR
+/// branches divide by vertex-elevation differences, and a cell this flat
+/// is the flat closure to more precision than the division would keep.
+const FLAT_RELIEF: f64 = 1e-9;
+
+/// A cell's sorted vertex elevations, the VFR closure's whole geometry.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CellBed {
+    /// Sorted: `z1 <= z2 <= z3` (m).
+    pub z1: f64,
+    pub z2: f64,
+    pub z3: f64,
+}
+
+impl CellBed {
+    pub fn new(a: f64, b: f64, c: f64) -> CellBed {
+        let mut z = [a, b, c];
+        z.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+        CellBed {
+            z1: z[0],
+            z2: z[1],
+            z3: z[2],
+        }
+    }
+
+    /// The centroid bed $\bar z$, the flat closure's datum.
+    pub fn mean(&self) -> f64 {
+        (self.z1 + self.z2 + self.z3) / 3.0
+    }
+
+    fn relief(&self) -> f64 {
+        self.z3 - self.z1
+    }
+}
+
+/// §15.3 FLAT: $\eta = \bar z + \bar h$.
+pub fn flat_eta(bed: &CellBed, h_mean: f64) -> f64 {
+    bed.mean() + h_mean
+}
+
+/// §15.3 VFR: mean depth at stage $\eta$, the exact planar-bed relation.
+/// The unregularised form; [`vfr_eta`] and its inverse apply the
+/// $\varepsilon$ floor.
+pub fn vfr_mean_depth(bed: &CellBed, eta: f64) -> f64 {
+    if bed.relief() < FLAT_RELIEF {
+        return (eta - bed.mean()).max(0.0);
+    }
+    let CellBed { z1, z2, z3 } = *bed;
+    if eta <= z1 {
+        0.0
+    } else if eta <= z2 {
+        let d = eta - z1;
+        d * d * d / (3.0 * (z2 - z1).max(FLAT_RELIEF) * (z3 - z1))
+    } else if eta <= z3 {
+        let d = z3 - eta;
+        (eta - bed.mean()) + d * d * d / (3.0 * (z3 - z1) * (z3 - z2).max(FLAT_RELIEF))
+    } else {
+        eta - bed.mean()
+    }
+}
+
+/// §15.3 VFR: the wet-area fraction $\mathrm{d}\bar h/\mathrm{d}\eta$ at
+/// stage $\eta$.
+pub fn vfr_wet_fraction(bed: &CellBed, eta: f64) -> f64 {
+    if bed.relief() < FLAT_RELIEF {
+        return 1.0;
+    }
+    let CellBed { z1, z2, z3 } = *bed;
+    if eta <= z1 {
+        0.0
+    } else if eta <= z2 {
+        let d = eta - z1;
+        d * d / ((z2 - z1).max(FLAT_RELIEF) * (z3 - z1))
+    } else if eta <= z3 {
+        let d = z3 - eta;
+        1.0 - d * d / ((z3 - z1) * (z3 - z2).max(FLAT_RELIEF))
+    } else {
+        1.0
+    }
+}
+
+/// The stage at which the wet fraction reaches `eps` — where the
+/// regularised relation departs the exact one.
+fn vfr_eps_stage(bed: &CellBed, eps: f64) -> f64 {
+    let CellBed { z1, z2, z3 } = *bed;
+    let lower_cap = (z2 - z1).max(FLAT_RELIEF) / (z3 - z1);
+    if eps <= lower_cap {
+        z1 + (eps * (z2 - z1).max(FLAT_RELIEF) * (z3 - z1)).sqrt()
+    } else {
+        z3 - ((1.0 - eps) * (z3 - z1) * (z3 - z2).max(FLAT_RELIEF)).sqrt()
+    }
+}
+
+/// §15.3 VFR, regularised: stage from mean depth. Above the
+/// $\varepsilon$-stage the exact inverse (closed-form cube root on the
+/// lower branch, safeguarded bisection on the middle one); below it the
+/// tangent continuation with slope $1/\varepsilon$ in $\eta(\bar h)$,
+/// keeping the closure $C^1$ and monotone as the cell dries.
+pub fn vfr_eta(bed: &CellBed, h_mean: f64, eps: f64) -> f64 {
+    if bed.relief() < FLAT_RELIEF {
+        return bed.mean() + h_mean;
+    }
+    let CellBed { z1, z2, z3 } = *bed;
+    let eta_s = vfr_eps_stage(bed, eps);
+    let h_s = vfr_mean_depth(bed, eta_s);
+    if h_mean <= h_s {
+        // Tangent continuation: dh̄/dη = ε below the ε-stage.
+        return eta_s - (h_s - h_mean) / eps.max(f64::MIN_POSITIVE);
+    }
+    if h_mean >= vfr_mean_depth(bed, z3) {
+        // Fully wet: exactly the flat closure.
+        return bed.mean() + h_mean;
+    }
+    if h_mean <= vfr_mean_depth(bed, z2) {
+        // Lower branch: closed-form cube root.
+        return z1 + (3.0 * h_mean * (z2 - z1).max(FLAT_RELIEF) * (z3 - z1)).cbrt();
+    }
+    // Middle branch: monotone in η on [z2, z3]; bisection to round-off.
+    let (mut lo, mut hi) = (z2, z3);
+    for _ in 0..80 {
+        let mid = 0.5 * (lo + hi);
+        if vfr_mean_depth(bed, mid) < h_mean {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if hi - lo <= 1e-14 * (1.0 + bed.relief()) {
+            break;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+/// §15.3 face depths. `MEAN`: the higher water surface over the face
+/// bed.
+pub fn face_depth_mean(eta_l: f64, eta_r: f64, z_face: f64) -> f64 {
+    eta_l.max(eta_r) - z_face
+}
+
+/// §15.3 `VFR_FACE`: the wetted-edge mean depth of the higher surface
+/// over the edge's own endpoint beds — $C^1$ at both joins.
+pub fn face_depth_vfr(eta_l: f64, eta_r: f64, z_lo: f64, z_hi: f64) -> f64 {
+    let eta = eta_l.max(eta_r);
+    if eta <= z_lo {
+        0.0
+    } else if z_hi - z_lo < FLAT_RELIEF {
+        eta - z_lo
+    } else if eta <= z_hi {
+        let d = eta - z_lo;
+        d * d / (2.0 * (z_hi - z_lo))
+    } else {
+        eta - 0.5 * (z_lo + z_hi)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bed() -> CellBed {
+        CellBed::new(10.4, 10.0, 10.2)
+    }
+
+    /// The relation's shape: zero at the low corner, the flat closure
+    /// when fully wet, continuous and strictly increasing between.
+    #[test]
+    fn vfr_runs_from_dry_corner_to_flat_closure() {
+        let b = bed();
+        assert_eq!(vfr_mean_depth(&b, 10.0), 0.0);
+        assert!((vfr_mean_depth(&b, 10.4) - (10.4 - b.mean())).abs() < 1e-12);
+        assert!((vfr_mean_depth(&b, 11.0) - (11.0 - b.mean())).abs() < 1e-12);
+        // Branch joins are continuous.
+        for z in [10.2, 10.4] {
+            let below = vfr_mean_depth(&b, z - 1e-9);
+            let above = vfr_mean_depth(&b, z + 1e-9);
+            assert!((above - below).abs() < 1e-8, "join at {z}");
+        }
+        // Strictly increasing.
+        let mut last = -1.0;
+        for i in 0..100 {
+            let eta = 10.0 + 0.005 * f64::from(i);
+            let h = vfr_mean_depth(&b, eta);
+            assert!(h >= last);
+            last = h;
+        }
+    }
+
+    /// The wet fraction is the relation's derivative, to first order.
+    #[test]
+    fn the_wet_fraction_is_the_slope() {
+        let b = bed();
+        for eta in [10.05, 10.15, 10.25, 10.35] {
+            let d = 1e-7;
+            let numeric = (vfr_mean_depth(&b, eta + d) - vfr_mean_depth(&b, eta - d)) / (2.0 * d);
+            assert!(
+                (vfr_wet_fraction(&b, eta) - numeric).abs() < 1e-5,
+                "at {eta}: {} vs {numeric}",
+                vfr_wet_fraction(&b, eta)
+            );
+        }
+    }
+
+    /// Stage and depth are exact inverses above the ε-stage, and the
+    /// tangent continuation round-trips below it.
+    #[test]
+    fn eta_and_depth_round_trip() {
+        let b = bed();
+        let eps = 0.01;
+        for h in [1e-6, 1e-4, 0.01, 0.05, 0.1, 0.2, 0.5, 2.0] {
+            let eta = vfr_eta(&b, h, eps);
+            let back = if vfr_wet_fraction(&b, eta) >= eps {
+                vfr_mean_depth(&b, eta)
+            } else {
+                // Below the ε-stage the forward relation is the tangent.
+                let eta_s = vfr_eps_stage(&b, eps);
+                vfr_mean_depth(&b, eta_s) - (eta_s - eta) * eps
+            };
+            assert!(
+                (back - h).abs() < 1e-10 * (1.0 + h),
+                "h={h}: eta={eta} back={back}"
+            );
+        }
+    }
+
+    /// The regularised closure is monotone through the ε-stage and never
+    /// puts a wet surface below the low corner by more than the tangent's
+    /// reach.
+    #[test]
+    fn the_regularisation_is_monotone_and_c1() {
+        let b = bed();
+        let eps = 0.01;
+        let mut last = f64::NEG_INFINITY;
+        for i in 0..2000 {
+            let h = 1e-8 * f64::from(i) * f64::from(i);
+            let eta = vfr_eta(&b, h, eps);
+            assert!(eta >= last, "monotone at h={h}");
+            last = eta;
+        }
+        // Slope continuity at the ε-stage: 1/ε on both sides.
+        let eta_s = vfr_eps_stage(&b, eps);
+        let h_s = vfr_mean_depth(&b, eta_s);
+        let d = 1e-9;
+        let below = (vfr_eta(&b, h_s, eps) - vfr_eta(&b, h_s - d, eps)) / d;
+        let above = (vfr_eta(&b, h_s + d, eps) - vfr_eta(&b, h_s, eps)) / d;
+        assert!(
+            (below / above - 1.0).abs() < 0.05,
+            "C1 at the ε-stage: {below} vs {above}"
+        );
+    }
+
+    /// A flat cell is the flat closure in both directions.
+    #[test]
+    fn a_flat_cell_is_flat() {
+        let b = CellBed::new(5.0, 5.0, 5.0);
+        assert!((vfr_mean_depth(&b, 5.3) - 0.3).abs() < 1e-12);
+        assert!((vfr_eta(&b, 0.3, 0.01) - 5.3).abs() < 1e-12);
+        assert_eq!(vfr_wet_fraction(&b, 5.3), 1.0);
+    }
+
+    /// The VFR face depth is C¹ at both joins and linear above the high
+    /// end.
+    #[test]
+    fn the_face_depth_joins_smoothly() {
+        let (z_lo, z_hi) = (10.0, 10.4);
+        assert_eq!(face_depth_vfr(9.9, 9.5, z_lo, z_hi), 0.0);
+        let mid = face_depth_vfr(10.2, 0.0, z_lo, z_hi);
+        assert!((mid - 0.2 * 0.2 / 0.8).abs() < 1e-12);
+        let above = face_depth_vfr(11.0, 0.0, z_lo, z_hi);
+        assert!((above - (11.0 - 10.2)).abs() < 1e-12);
+        for z in [z_lo, z_hi] {
+            let below = face_depth_vfr(z - 1e-9, 0.0, z_lo, z_hi);
+            let over = face_depth_vfr(z + 1e-9, 0.0, z_lo, z_hi);
+            assert!((over - below).abs() < 1e-8, "join at {z}");
+        }
+    }
+}

--- a/crates/engine-uds/src/overland/coupling.rs
+++ b/crates/engine-uds/src/overland/coupling.rs
@@ -1,0 +1,185 @@
+//! §15.6: the junction-exchange orifice law and its regularisations.
+//!
+//! Pure functions of the two heads and the point's geometry. The
+//! marcher evaluates them at tier-0 cadence; the network side reads the
+//! conductance for its §6.4 damping. Everything is SI (m, m², m³/s).
+
+/// Regularisation head (m) below which the orifice root is replaced by
+/// the value-and-slope-matched quadratic (§15.6): the bare root's
+/// infinite slope at equal heads is exactly the stiffness that makes
+/// near-equal heads oscillate.
+pub const ORIFICE_EPS: f64 = 0.02;
+
+/// The band (m) above the rim over which the gate opens and the
+/// exchange area ramps (§15.6).
+pub const RIM_BAND: f64 = 0.05;
+
+const G: f64 = 9.80665;
+
+/// The C¹ smoothstep on \[0, 1\].
+fn smoothstep(t: f64) -> f64 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// $\varphi(x)$: $\sqrt x$ beyond the regularisation head, the C¹
+/// quadratic below it.
+pub fn orifice_phi(x: f64) -> f64 {
+    if x >= ORIFICE_EPS {
+        x.sqrt()
+    } else {
+        let inv = 1.0 / ORIFICE_EPS.sqrt();
+        1.5 * inv * x - 0.5 * inv / ORIFICE_EPS * x * x
+    }
+}
+
+/// $\varphi'(x)$, for the conductance.
+pub fn orifice_phi_prime(x: f64) -> f64 {
+    if x >= ORIFICE_EPS {
+        0.5 / x.sqrt()
+    } else {
+        let inv = 1.0 / ORIFICE_EPS.sqrt();
+        1.5 * inv - inv / ORIFICE_EPS * x
+    }
+}
+
+/// The rim gate: opens C¹ over the band above the rim, evaluated at the
+/// higher of the two surfaces — exchange exists only when either side
+/// reaches the ground (§15.6).
+pub fn rim_gate(h_max: f64, rim: f64) -> f64 {
+    smoothstep((h_max - rim) / RIM_BAND)
+}
+
+/// The effective exchange area: authored below ground, ramped 1× to 2×
+/// over the band above it (§15.6).
+pub fn effective_area(h_max: f64, rim: f64, area: f64) -> f64 {
+    if h_max < rim {
+        area
+    } else {
+        area * (1.0 + ((h_max - rim) / RIM_BAND).min(1.0))
+    }
+}
+
+/// The §15.4.3 wetting ramp on the source side's depth.
+pub fn wet_ramp(depth: f64, dry_depth: f64) -> f64 {
+    smoothstep(depth / dry_depth)
+}
+
+/// §15.6 junction exchange. Positive drains the surface into the node;
+/// negative spills the node onto the surface.
+#[allow(clippy::too_many_arguments)]
+pub fn exchange_q(
+    h_2d: f64,
+    h_1d: f64,
+    rim: f64,
+    cd: f64,
+    area: f64,
+    depth_2d: f64,
+    depth_1d: f64,
+    dry_depth: f64,
+) -> f64 {
+    let dh = h_2d - h_1d;
+    if dh.abs() < 1e-12 {
+        return 0.0;
+    }
+    let h_max = h_2d.max(h_1d);
+    let a_eff = effective_area(h_max, rim, area);
+    let mut q = dh.signum() * cd * a_eff * (2.0 * G).sqrt() * orifice_phi(dh.abs());
+    q *= rim_gate(h_max, rim);
+    q *= if q > 0.0 {
+        wet_ramp(depth_2d, dry_depth)
+    } else {
+        wet_ramp(depth_1d, dry_depth)
+    };
+    q
+}
+
+/// §15.6 exchange conductance $G = -\partial Q/\partial h_{1D} \geq 0$.
+/// The gate and ramp factors are held constant — their derivatives are
+/// deliberately dropped so the sign guarantee, a pure damping term on
+/// the node's continuity denominator, cannot be violated.
+#[allow(clippy::too_many_arguments)]
+pub fn exchange_conductance(
+    h_2d: f64,
+    h_1d: f64,
+    rim: f64,
+    cd: f64,
+    area: f64,
+    depth_2d: f64,
+    depth_1d: f64,
+    dry_depth: f64,
+) -> f64 {
+    let h_max = h_2d.max(h_1d);
+    let a_eff = effective_area(h_max, rim, area);
+    let mut g = cd * a_eff * (2.0 * G).sqrt() * orifice_phi_prime((h_2d - h_1d).abs());
+    g *= rim_gate(h_max, rim);
+    g *= wet_ramp(depth_2d.max(depth_1d), dry_depth);
+    g.max(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// φ meets the bare root with matched value and slope, and holds a
+    /// finite slope at zero.
+    #[test]
+    fn the_regularised_root_is_c1() {
+        let e = ORIFICE_EPS;
+        assert!((orifice_phi(e) - e.sqrt()).abs() < 1e-14);
+        let d = 1e-9;
+        let below = (orifice_phi(e) - orifice_phi(e - d)) / d;
+        let above = (orifice_phi(e + d) - orifice_phi(e)) / d;
+        assert!((below / above - 1.0).abs() < 1e-4, "{below} vs {above}");
+        assert_eq!(orifice_phi(0.0), 0.0);
+        assert!(orifice_phi_prime(0.0).is_finite());
+        // φ′ is φ's derivative on both branches.
+        for x in [0.001, 0.01, 0.05, 0.5] {
+            let n = (orifice_phi(x + d) - orifice_phi(x - d)) / (2.0 * d);
+            assert!((orifice_phi_prime(x) - n).abs() < 1e-4, "at {x}");
+        }
+    }
+
+    /// Exchange is signed by the head difference, zero at equal heads,
+    /// and shut while both surfaces stand below the rim.
+    #[test]
+    fn the_exchange_is_signed_and_rim_gated() {
+        let q = |h2, h1| exchange_q(h2, h1, 10.0, 0.65, 1.0, 1.0, 1.0, 0.001);
+        assert_eq!(q(11.0, 11.0), 0.0);
+        assert!(q(11.0, 10.5) > 0.0, "surface above node drains");
+        assert!(q(10.5, 11.0) < 0.0, "node above surface spills");
+        assert_eq!(q(9.5, 9.0), 0.0, "both below the rim: no exchange");
+        // The gate is C¹: half a band above the rim it is partial.
+        let half = q(10.0 + RIM_BAND / 2.0, 9.0);
+        let open = q(10.0 + 2.0 * RIM_BAND, 9.0);
+        assert!(half > 0.0 && half < open);
+    }
+
+    /// The exchange area ramps from the authored value to twice it over
+    /// the band above the rim.
+    #[test]
+    fn the_area_ramps_to_double_above_ground() {
+        assert_eq!(effective_area(9.0, 10.0, 0.7), 0.7);
+        assert_eq!(effective_area(10.0 + RIM_BAND, 10.0, 0.7), 1.4);
+        assert_eq!(effective_area(12.0, 10.0, 0.7), 1.4);
+        let mid = effective_area(10.0 + RIM_BAND / 2.0, 10.0, 0.7);
+        assert!((mid - 1.05).abs() < 1e-12);
+    }
+
+    /// The conductance is the head sensitivity where the gate and ramps
+    /// are fully open, and never negative anywhere.
+    #[test]
+    fn the_conductance_is_the_drain_slope() {
+        let (rim, cd, area, dd) = (10.0, 0.65, 1.0, 0.001);
+        let (h2, h1) = (11.0, 10.6);
+        let d = 1e-7;
+        let numeric = -(exchange_q(h2, h1 + d, rim, cd, area, 1.0, 0.6, dd)
+            - exchange_q(h2, h1 - d, rim, cd, area, 1.0, 0.6, dd))
+            / (2.0 * d);
+        let g = exchange_conductance(h2, h1, rim, cd, area, 1.0, 0.6, dd);
+        assert!((g / numeric - 1.0).abs() < 1e-4, "{g} vs {numeric}");
+        for (a, b) in [(9.0, 8.0), (10.0, 10.0), (10.02, 10.0), (8.0, 12.0)] {
+            assert!(exchange_conductance(a, b, rim, cd, area, 0.5, 0.5, dd) >= 0.0);
+        }
+    }
+}

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -9,8 +9,10 @@
 //! a value the single-tier march produces at the same steps.
 
 use super::closure::{face_depth_mean, face_depth_vfr, flat_eta, vfr_eta, CellBed};
+use super::coupling::{exchange_conductance, exchange_q};
 use super::{
-    BoundaryCondition, CellClosure, FaceReconstruction, OverlandMesh, SeriesOrValue, Topology,
+    BoundaryCondition, CellClosure, CouplingRow, FaceReconstruction, OverlandMesh, SeriesOrValue,
+    Topology,
 };
 
 /// §15.1: standard gravity (m/s²).
@@ -67,10 +69,19 @@ struct Boundary {
     /// Prognostic discharge of the stage law's inertial arm (m²/s,
     /// inflow positive).
     q: f64,
+    /// The edge's sill (higher endpoint elevation, m), the rating law's
+    /// datum (§15.5).
+    z_sill: f64,
+    /// §15.5: a series- or curve-driven slot is a wall until its first
+    /// resolution.
+    enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum BoundaryLaw {
+    /// §15.5 `RATING_CURVE`: per-metre discharge from a curve of stage
+    /// above the edge sill, re-read every firing.
+    Rating { curve: u32 },
     /// Manning outfall at the authored bed slope.
     NormalFlow { slope: f64 },
     /// Held per-metre discharge (m³/s per m, authored outward positive).
@@ -83,7 +94,8 @@ enum BoundaryLaw {
 /// [`Marcher::advance`].
 pub struct Marcher {
     // ── Geometry ────────────────────────────────────────────────────
-    area: Vec<f64>,
+    /// Cell planimetric areas (m²) — public for §15.6 footprint sums.
+    pub area: Vec<f64>,
     /// Cell centroids (m), for the Perot offset (§15.4.3).
     cx: Vec<f64>,
     cy: Vec<f64>,
@@ -140,11 +152,83 @@ pub struct Marcher {
     pub evap: Vec<f64>,
     pub coupling: Vec<f64>,
 
+    // ── §15.6 coupling ─────────────────────────────────────────────
+    couplings: Vec<CouplingPoint>,
+    /// Distinct coupled node names, in slot order.
+    node_names: Vec<String>,
+    /// Per-slot drive, set before an advance: node hydraulic grade,
+    /// node water depth, rim elevation (all m), and the volume
+    /// available to spill over the whole advance (m³).
+    node_grade: Vec<f64>,
+    node_depth: Vec<f64>,
+    node_rim: Vec<f64>,
+    node_spill_avail: Vec<f64>,
+    /// §15.6 per-advance spill ledger: the same water cannot spill
+    /// twice within one routing step.
+    node_drawn: Vec<f64>,
+    /// §15.6: slots naming an outfall exchange through the boundary
+    /// stage and injection paths, never the junction orifice law.
+    outfall_slot: Vec<bool>,
+    /// Signed exchanged volume per point over the last advance (m³,
+    /// positive = drained into the node).
+    exchange: Vec<f64>,
+
+    // ── §15.5 driven boundaries ────────────────────────────────────
+    /// Slots whose stage or flow the session resolves per advance.
+    driven: Vec<DrivenBoundary>,
+    /// Distinct rating-curve names, in first-appearance order, and the
+    /// resolved curves (stage above sill → per-metre discharge).
+    rating_names: Vec<String>,
+    rating_curves: Vec<Vec<(f64, f64)>>,
+
     // ── §15.8 ledger (m³ since construction) ───────────────────────
     pub rain_in: f64,
     pub evap_out: f64,
     pub boundary_in: f64,
     pub boundary_out: f64,
+    /// Junction exchange (§15.6 orifice law): spills in, drains out.
+    pub coupling_in: f64,
+    pub coupling_out: f64,
+    /// Outfall exchange (§15.6 injection path): discharges in,
+    /// withdrawals out — booked separately per §15.8.
+    pub outfall_in: f64,
+    pub outfall_out: f64,
+}
+
+/// §15.5: a boundary slot whose law the session resolves per advance
+/// from an authored time series.
+#[derive(Debug, Clone)]
+pub struct DrivenBoundary {
+    /// Index into the marcher's boundary list.
+    pub boundary: usize,
+    /// The authored series name, resolved by the session.
+    pub series: String,
+    /// Stage series (`true`) or flow series (`false`).
+    pub is_stage: bool,
+}
+
+/// §15.6: a resolved coupling point. A vertex row collapses to the
+/// lowest-bed cell of its stencil for the orifice exchange; the stencil
+/// and the vertex remain for outfall-injection scattering.
+#[derive(Debug, Clone)]
+pub struct CouplingPoint {
+    /// The cell both directions of the exchange apply at.
+    pub cell: u32,
+    /// The vertex's incident cells (a cell row: the cell alone).
+    pub stencil: Vec<u32>,
+    /// The vertex position and ground elevation, `None` for a cell row.
+    pub vertex: Option<(f64, f64, f64)>,
+    /// The exchange slot: points naming one network node share a slot,
+    /// its drive, and its spill ledger.
+    pub node_slot: u32,
+    /// The network node as authored, for the session to resolve (§2.6).
+    pub node: String,
+    /// Discharge coefficient (§15.6).
+    pub cd: f64,
+    /// Exchange area (m²).
+    pub area: f64,
+    /// Unauthored areas are eligible for `COUPLING_AREA AUTO` (§15.6).
+    pub area_authored: bool,
 }
 
 impl Marcher {
@@ -225,7 +309,13 @@ impl Marcher {
 
         // Boundary laws from the validated rows; walls stay implicit.
         let mut boundaries = Vec::new();
+        let mut driven: Vec<DrivenBoundary> = Vec::new();
+        let mut rating_names: Vec<String> = Vec::new();
         for row in &mesh.boundaries {
+            // §15.5: series and curve parameters resolve at the wiring
+            // layer; a slot is a wall until its first resolution.
+            let mut enabled = true;
+            let mut series: Option<(String, bool)> = None;
             let law = match &row.condition {
                 BoundaryCondition::Wall => continue,
                 BoundaryCondition::NormalFlow { slope } => {
@@ -235,15 +325,37 @@ impl Marcher {
                     BoundaryLaw::Flow { q_per_m: *v }
                 }
                 BoundaryCondition::Stage(SeriesOrValue::Value(v)) => BoundaryLaw::Stage { eta: *v },
-                // Series and curves resolve to per-advance values at the
-                // wiring layer; until then the slot is a wall, which is
-                // the refusal-safe reading of an unresolved parameter.
-                BoundaryCondition::Flow(SeriesOrValue::Series(_))
-                | BoundaryCondition::Stage(SeriesOrValue::Series(_))
-                | BoundaryCondition::RatingCurve { .. } => continue,
+                BoundaryCondition::Flow(SeriesOrValue::Series(name)) => {
+                    enabled = false;
+                    series = Some((name.clone(), false));
+                    BoundaryLaw::Flow { q_per_m: 0.0 }
+                }
+                BoundaryCondition::Stage(SeriesOrValue::Series(name)) => {
+                    enabled = false;
+                    series = Some((name.clone(), true));
+                    BoundaryLaw::Stage { eta: 0.0 }
+                }
+                BoundaryCondition::RatingCurve { curve } => {
+                    enabled = false;
+                    let slot = match rating_names.iter().position(|n| n == curve) {
+                        Some(i) => i,
+                        None => {
+                            rating_names.push(curve.clone());
+                            rating_names.len() - 1
+                        }
+                    };
+                    BoundaryLaw::Rating { curve: slot as u32 }
+                }
             };
             let slot = row.cell as usize * 3 + row.edge as usize;
             let xi = topo.edge_len[slot];
+            if let Some((name, is_stage)) = series {
+                driven.push(DrivenBoundary {
+                    boundary: boundaries.len(),
+                    series: name,
+                    is_stage,
+                });
+            }
             boundaries.push(Boundary {
                 cell: row.cell,
                 xi,
@@ -252,6 +364,8 @@ impl Marcher {
                 my: topo.edge_mid[slot][1],
                 inv_dn_ghost: 3.0 * xi / (2.0 * topo.area[row.cell as usize]),
                 q: 0.0,
+                z_sill: topo.edge_z[slot][0].max(topo.edge_z[slot][1]),
+                enabled,
             });
         }
 
@@ -278,6 +392,63 @@ impl Marcher {
                 0.5 * ((ul + ur) * f.nx + (vl + vr) * f.ny)
             })
             .collect();
+
+        // §15.6: resolve coupling rows. Two rows resolving to one
+        // vertex (or cell) are one coupling, the last authored winning.
+        let z_mean_of = |ci: usize| bed[ci].mean();
+        let mut resolved: Vec<(Option<u32>, Option<u32>, &CouplingRow)> = Vec::new();
+        for row in &mesh.vertex_couplings {
+            if let Some(v) = mesh.resolve_vertex(&row.address) {
+                resolved.retain(|(rv, _, _)| *rv != Some(v));
+                resolved.push((Some(v), None, row));
+            }
+        }
+        for row in &mesh.cell_couplings {
+            if let Some(c) = mesh.resolve_cell(&row.address) {
+                resolved.retain(|(_, rc, _)| *rc != Some(c));
+                resolved.push((None, Some(c), row));
+            }
+        }
+        let mut couplings: Vec<CouplingPoint> = Vec::new();
+        let mut node_names: Vec<String> = Vec::new();
+        for (v, c, row) in resolved {
+            let (cell, stencil, vertex) = if let Some(v) = v {
+                let stencil: Vec<u32> = (0..nc)
+                    .filter(|&ci| mesh.cells[ci].v.contains(&v))
+                    .map(|ci| ci as u32)
+                    .collect();
+                let Some(&cell) = stencil
+                    .iter()
+                    .min_by(|&&a, &&b| z_mean_of(a as usize).total_cmp(&z_mean_of(b as usize)))
+                else {
+                    continue;
+                };
+                let vr = &mesh.verts[v as usize];
+                (cell, stencil, Some((vr.x, vr.y, vr.z)))
+            } else {
+                let cell = c.unwrap_or(0);
+                (cell, vec![cell], None)
+            };
+            let slot = match node_names.iter().position(|n| n == &row.node) {
+                Some(i) => i,
+                None => {
+                    node_names.push(row.node.clone());
+                    node_names.len() - 1
+                }
+            } as u32;
+            couplings.push(CouplingPoint {
+                cell,
+                stencil,
+                vertex,
+                node_slot: slot,
+                node: row.node.clone(),
+                cd: row.cd,
+                area: row.area,
+                area_authored: row.area_authored,
+            });
+        }
+        let ns = node_names.len();
+        let np = couplings.len();
 
         let nf = faces.len();
         let mut m = Marcher {
@@ -317,10 +488,26 @@ impl Marcher {
             rain: vec![0.0; nc],
             evap: vec![0.0; nc],
             coupling: vec![0.0; nc],
+            couplings,
+            node_names,
+            node_grade: vec![0.0; ns],
+            node_depth: vec![0.0; ns],
+            node_rim: vec![0.0; ns],
+            node_spill_avail: vec![0.0; ns],
+            node_drawn: vec![0.0; ns],
+            outfall_slot: vec![false; ns],
+            exchange: vec![0.0; np],
+            driven,
+            rating_curves: vec![Vec::new(); rating_names.len()],
+            rating_names,
             rain_in: 0.0,
             evap_out: 0.0,
             boundary_in: 0.0,
             boundary_out: 0.0,
+            coupling_in: 0.0,
+            coupling_out: 0.0,
+            outfall_in: 0.0,
+            outfall_out: 0.0,
         };
         for ci in 0..nc {
             m.reclose(ci);
@@ -405,6 +592,16 @@ impl Marcher {
         for b in &self.boundaries {
             next[b.cell as usize] = true;
         }
+        // §15.4.4: cells with coupling points or held injection are
+        // always active.
+        for cp in &self.couplings {
+            next[cp.cell as usize] = true;
+        }
+        for (ci, r) in self.coupling.iter().enumerate() {
+            if *r != 0.0 {
+                next[ci] = true;
+            }
+        }
         self.active = next;
     }
 
@@ -450,6 +647,216 @@ impl Marcher {
         self.q[fi].clamp(-cap, cap)
     }
 
+    /// §15.6: junction exchange at tier-0 cadence, sequentially, in
+    /// point order. A drain takes at most the β share of its source
+    /// cell per substep; a spill draws against the node's advance-wide
+    /// ledger — the same water cannot spill twice.
+    fn fire_couplings(&mut self, dt: f64) {
+        for k in 0..self.couplings.len() {
+            let cp = &self.couplings[k];
+            let ci = cp.cell as usize;
+            let slot = cp.node_slot as usize;
+            if self.outfall_slot[slot] {
+                // §15.6: outfall coupling is asymmetric — no orifice law.
+                continue;
+            }
+            let mut q = exchange_q(
+                self.eta[ci],
+                self.node_grade[slot],
+                self.node_rim[slot],
+                cp.cd,
+                cp.area,
+                self.depth[ci],
+                self.node_depth[slot],
+                self.dry_depth,
+            );
+            if q == 0.0 {
+                continue;
+            }
+            if q > 0.0 {
+                q = q.min(BETA * self.vol[ci].max(0.0) / dt);
+            } else {
+                let avail = (self.node_spill_avail[slot] - self.node_drawn[slot]).max(0.0);
+                if avail <= 0.0 {
+                    continue;
+                }
+                let take = (-q * dt).min(avail);
+                self.node_drawn[slot] += take;
+                q = -take / dt;
+            }
+            let dv = q * dt;
+            self.vol[ci] = (self.vol[ci] - dv).max(0.0);
+            if dv > 0.0 {
+                self.coupling_out += dv;
+            } else {
+                self.coupling_in += -dv;
+            }
+            self.exchange[k] += dv;
+            self.reclose(ci);
+        }
+    }
+
+    /// The §15.4.4 drying depth (m), for callers keying wetness ramps.
+    pub fn dry_depth(&self) -> f64 {
+        self.dry_depth
+    }
+
+    /// §15.6: mark a slot as naming an outfall — its points leave the
+    /// junction orifice law to the boundary-stage and injection paths.
+    pub fn mark_outfall_slot(&mut self, slot: usize) {
+        self.outfall_slot[slot] = true;
+    }
+
+    /// Whether a slot was marked as an outfall.
+    pub fn is_outfall_slot(&self, slot: usize) -> bool {
+        self.outfall_slot[slot]
+    }
+
+    /// §15.5: the boundary slots whose stage or flow the session must
+    /// resolve per advance.
+    pub fn driven_boundaries(&self) -> &[DrivenBoundary] {
+        &self.driven
+    }
+
+    /// §15.5: resolve a driven slot's flow (m³/s per metre, outward
+    /// positive as authored). The slot conveys from now on.
+    pub fn set_boundary_flow(&mut self, bi: usize, q_per_m: f64) {
+        self.boundaries[bi].law = BoundaryLaw::Flow { q_per_m };
+        self.boundaries[bi].enabled = true;
+    }
+
+    /// §15.5: resolve a driven slot's stage (m). The slot conveys from
+    /// now on.
+    pub fn set_boundary_stage(&mut self, bi: usize, eta: f64) {
+        self.boundaries[bi].law = BoundaryLaw::Stage { eta };
+        self.boundaries[bi].enabled = true;
+    }
+
+    /// Distinct rating-curve names, in slot order.
+    pub fn rating_curve_names(&self) -> &[String] {
+        &self.rating_names
+    }
+
+    /// §15.5: supply a rating curve's points (stage above the edge sill
+    /// (m) → per-metre discharge, sorted by stage). Every boundary slot
+    /// reading this curve conveys from now on.
+    pub fn set_rating_curve(&mut self, slot: usize, points: Vec<(f64, f64)>) {
+        self.rating_curves[slot] = points;
+        for b in &mut self.boundaries {
+            if matches!(b.law, BoundaryLaw::Rating { curve } if curve as usize == slot) {
+                b.enabled = true;
+            }
+        }
+    }
+
+    /// The resolved §15.6 coupling points, in authored (post last-wins)
+    /// order.
+    pub fn coupling_points(&self) -> &[CouplingPoint] {
+        &self.couplings
+    }
+
+    /// Distinct coupled node names, in slot order; drives and spill
+    /// budgets are addressed by these slots.
+    pub fn coupling_nodes(&self) -> &[String] {
+        &self.node_names
+    }
+
+    /// §15.6: set a node slot's drive for the coming advance — its
+    /// hydraulic grade, water depth and rim elevation (m), and the
+    /// volume available to spill over the whole advance (m³).
+    pub fn set_node_drive(&mut self, slot: usize, grade: f64, depth: f64, rim: f64, spill: f64) {
+        self.node_grade[slot] = grade;
+        self.node_depth[slot] = depth;
+        self.node_rim[slot] = rim;
+        self.node_spill_avail[slot] = spill;
+    }
+
+    /// Resolve a `COUPLING_AREA AUTO` derivation (§15.6): the session
+    /// overrides unauthored areas from the node's largest connected
+    /// conduit before the first advance.
+    pub fn set_coupling_area(&mut self, point: usize, area: f64) {
+        self.couplings[point].area = area;
+    }
+
+    /// Signed exchanged volume per point over the last advance (m³,
+    /// positive = drained into the node).
+    pub fn exchanged(&self) -> &[f64] {
+        &self.exchange
+    }
+
+    /// §15.6: the exchange conductance of a point against the current
+    /// surface, for the §6.4 vertex damping. Never negative.
+    pub fn coupling_conductance(&self, point: usize) -> f64 {
+        let cp = &self.couplings[point];
+        let ci = cp.cell as usize;
+        let slot = cp.node_slot as usize;
+        exchange_conductance(
+            self.eta[ci],
+            self.node_grade[slot],
+            self.node_rim[slot],
+            cp.cd,
+            cp.area,
+            self.depth[ci],
+            self.node_depth[slot],
+            self.dry_depth,
+        )
+    }
+
+    /// Clear every held injection rate (§15.6 outfall network→surface).
+    pub fn clear_injection(&mut self) {
+        for r in &mut self.coupling {
+            *r = 0.0;
+        }
+    }
+
+    /// §15.6: scatter an outfall's injection (m³/s) across a point's
+    /// stencil, weighted by the surface slope from the vertex down
+    /// toward each cell, falling back to area weights on a flat or dry
+    /// surface. The rates persist until cleared.
+    pub fn inject(&mut self, point: usize, rate: f64) {
+        let cp = self.couplings[point].clone();
+        let weights: Vec<f64> = if let Some((vx, vy, vz)) = cp.vertex {
+            // η_v: wet-depth-weighted mean surface of the wet stencil
+            // cells, the vertex ground elevation when all are dry.
+            let (mut num, mut den) = (0.0, 0.0);
+            for &t in &cp.stencil {
+                let t = t as usize;
+                if self.depth[t] >= self.dry_depth {
+                    num += self.depth[t] * self.eta[t];
+                    den += self.depth[t];
+                }
+            }
+            let eta_v = if den > 0.0 { num / den } else { vz };
+            cp.stencil
+                .iter()
+                .map(|&t| {
+                    let t = t as usize;
+                    let d = (self.cx[t] - vx).hypot(self.cy[t] - vy);
+                    if d < 1e-9 {
+                        0.0
+                    } else {
+                        ((eta_v - self.eta[t]) / d).max(0.0)
+                    }
+                })
+                .collect()
+        } else {
+            vec![1.0]
+        };
+        let wsum: f64 = weights.iter().sum();
+        if wsum > 1e-30 {
+            for (&t, w) in cp.stencil.iter().zip(&weights) {
+                let t = t as usize;
+                self.coupling[t] += rate * (w / wsum) / self.area[t];
+            }
+        } else {
+            let asum: f64 = cp.stencil.iter().map(|&t| self.area[t as usize]).sum();
+            for &t in &cp.stencil {
+                let t = t as usize;
+                self.coupling[t] += rate / asum;
+            }
+        }
+    }
+
     /// §15.4.4: re-tiering invalidates the positivity bookkeeping of
     /// in-flight accumulators, so gather every pending side into its
     /// cell first, and re-close the cells that changed.
@@ -491,6 +898,15 @@ impl Marcher {
         }
         for b in &self.boundaries {
             self.tier[b.cell as usize] = 0;
+        }
+        // §15.4.4: coupling and injection cells are pinned to tier 0.
+        for cp in &self.couplings {
+            self.tier[cp.cell as usize] = 0;
+        }
+        for (ci, r) in self.coupling.iter().enumerate() {
+            if *r != 0.0 {
+                self.tier[ci] = 0;
+            }
         }
         for (fi, f) in self.faces.iter().enumerate() {
             self.face_tier[fi] = self.tier[f.cl as usize].min(self.tier[f.cr as usize]);
@@ -590,6 +1006,13 @@ impl Marcher {
             let rain = self.rain[ci] * a * dt;
             let coup = self.coupling[ci] * a * dt;
             self.rain_in += rain;
+            // §15.8: the injection path books separately from the
+            // junction orifice exchange.
+            if coup >= 0.0 {
+                self.outfall_in += coup;
+            } else {
+                self.outfall_out += -coup;
+            }
             // §15.4.3: evaporation shuts off C¹ as the cell dries, and
             // takes no more than the cell holds.
             let t = (self.depth[ci] / self.dry_depth).clamp(0.0, 1.0);
@@ -609,10 +1032,35 @@ impl Marcher {
     fn fire_boundaries(&mut self, dt: f64) {
         for bi in 0..self.boundaries.len() {
             let b = &self.boundaries[bi];
+            if !b.enabled {
+                // §15.5: an unresolved series or curve slot is a wall.
+                continue;
+            }
             let ci = b.cell as usize;
             let h = self.depth[ci];
             // Inflow-positive volume the law asks to move this substep.
             let asked: f64 = match b.law {
+                BoundaryLaw::Rating { curve } => {
+                    // §15.5: stage above the edge sill, re-read every
+                    // firing; linear between points, held at the ends.
+                    let head = (self.eta[ci] - b.z_sill).max(0.0);
+                    let pts = &self.rating_curves[curve as usize];
+                    let q = match pts.iter().position(|p| p.0 >= head) {
+                        _ if pts.is_empty() => 0.0,
+                        None => pts[pts.len() - 1].1,
+                        Some(0) => pts[0].1,
+                        Some(i) => {
+                            let (x0, y0) = pts[i - 1];
+                            let (x1, y1) = pts[i];
+                            y0 + (y1 - y0) * (head - x0) / (x1 - x0).max(1e-30)
+                        }
+                    };
+                    if h <= self.dry_depth {
+                        0.0
+                    } else {
+                        -q * b.xi * dt
+                    }
+                }
                 BoundaryLaw::NormalFlow { slope } => {
                     if h <= self.dry_depth || slope <= 0.0 {
                         0.0
@@ -695,6 +1143,15 @@ impl Marcher {
     /// Advance to exactly `span` seconds from now (§15.4.4: an advance
     /// always reaches its target).
     pub fn advance(&mut self, span: f64) {
+        // §15.6 per-advance state: the spill ledger and the exchange
+        // totals reset; the same water cannot spill twice within one
+        // routing step.
+        for d in &mut self.node_drawn {
+            *d = 0.0;
+        }
+        for e in &mut self.exchange {
+            *e = 0.0;
+        }
         let mut remaining = span;
         let nsub = 1u64 << self.lts_tiers.saturating_sub(1).min(7);
         let mut dt0 = self.stable_dt();
@@ -727,6 +1184,7 @@ impl Marcher {
                     self.fire_faces(dt, 0);
                     self.fire_cells(dt, 0);
                     self.fire_boundaries(dt);
+                    self.fire_couplings(dt);
                     remaining -= dt;
                 }
                 self.macro_cycles += 1;
@@ -736,6 +1194,7 @@ impl Marcher {
                 self.fire_faces(dt0, s);
                 self.fire_cells(dt0, s);
                 self.fire_boundaries(dt0);
+                self.fire_couplings(dt0);
             }
             remaining -= dt0 * nsub as f64;
             self.macro_cycles += 1;
@@ -1368,6 +1827,266 @@ mod tests {
             "SWASHES bump relative L1 depth error {}",
             err / norm
         );
+    }
+
+    /// §15.5: a series-driven slot is a wall until its first
+    /// resolution, and conveys from then on.
+    #[test]
+    fn a_driven_boundary_is_a_wall_until_resolved() {
+        let mut mesh = grid(3, 3, 1.0, |_, _| 10.0);
+        fill_to_stage(&mut mesh, 10.4);
+        let topo = Topology::build(&mesh).expect("valid");
+        let (ci, e) = (0..mesh.cells.len() * 3)
+            .find(|slot| topo.neighbour[*slot].is_none())
+            .map(|slot| (slot / 3, slot % 3))
+            .expect("boundary edge");
+        mesh.boundaries.push(crate::overland::BoundaryRow {
+            cell: ci as u32,
+            edge: e as u8,
+            condition: BoundaryCondition::Flow(SeriesOrValue::Series("QB".into())),
+            group: None,
+        });
+        let mut m = build(&mesh);
+        assert_eq!(m.driven_boundaries().len(), 1);
+        assert_eq!(m.driven_boundaries()[0].series, "QB");
+        let v0 = m.storage();
+        m.advance(30.0);
+        assert!(
+            (m.storage() - v0).abs() < 1e-12,
+            "unresolved slot must wall"
+        );
+        let bi = m.driven_boundaries()[0].boundary;
+        m.set_boundary_flow(bi, 0.05);
+        m.advance(30.0);
+        assert!(m.storage() < v0, "resolved slot must convey");
+        assert!(m.boundary_out > 0.0);
+    }
+
+    /// §15.5: a rating outlet reads its curve of stage above the edge
+    /// sill at every firing — linear between points, held at the ends,
+    /// dry-gated.
+    #[test]
+    fn a_rating_outlet_follows_its_curve() {
+        let mut mesh = grid(3, 3, 1.0, |_, _| 10.0);
+        fill_to_stage(&mut mesh, 10.5);
+        let topo = Topology::build(&mesh).expect("valid");
+        let (ci, e) = (0..mesh.cells.len() * 3)
+            .find(|slot| topo.neighbour[*slot].is_none())
+            .map(|slot| (slot / 3, slot % 3))
+            .expect("boundary edge");
+        mesh.boundaries.push(crate::overland::BoundaryRow {
+            cell: ci as u32,
+            edge: e as u8,
+            condition: BoundaryCondition::RatingCurve { curve: "RC".into() },
+            group: None,
+        });
+        let mut m = build(&mesh);
+        assert_eq!(m.rating_curve_names(), ["RC"]);
+        // Unsupplied curve: wall.
+        let v0 = m.storage();
+        m.advance(10.0);
+        assert!((m.storage() - v0).abs() < 1e-12);
+        // Head 0.5 on a curve rising 0 → 0.5 m²/s over a metre of
+        // head: q = 0.25 per metre of edge.
+        m.set_rating_curve(0, vec![(0.0, 0.0), (1.0, 0.5)]);
+        let xi = 1.0; // grid edges are dx long
+        let before = m.boundary_out;
+        m.advance(4.0);
+        let out = m.boundary_out - before;
+        let expect = 0.25 * xi * 4.0;
+        assert!(
+            (out / expect - 1.0).abs() < 0.10,
+            "rated outflow {out} vs {expect}"
+        );
+        // Held at the top end: far above the last point the discharge
+        // is the last point's.
+        let mut mesh2 = grid(3, 3, 1.0, |_, _| 10.0);
+        fill_to_stage(&mut mesh2, 13.0);
+        mesh2.boundaries.push(crate::overland::BoundaryRow {
+            cell: ci as u32,
+            edge: e as u8,
+            condition: BoundaryCondition::RatingCurve { curve: "RC".into() },
+            group: None,
+        });
+        let mut m2 = build(&mesh2);
+        m2.set_rating_curve(0, vec![(0.0, 0.0), (1.0, 0.5)]);
+        let before = m2.boundary_out;
+        m2.advance(2.0);
+        let out = m2.boundary_out - before;
+        let expect = 0.5 * xi * 2.0;
+        assert!(
+            (out / expect - 1.0).abs() < 0.10,
+            "clamped outflow {out} vs {expect}"
+        );
+    }
+
+    /// §15.6: a vertex row collapses to the lowest-bed incident cell,
+    /// two spellings of one vertex are one coupling (last wins), and
+    /// points naming one node share a slot.
+    #[test]
+    fn a_vertex_coupling_collapses_to_the_lowest_bed_cell() {
+        let mut mesh = grid(2, 2, 1.0, |x, y| 10.0 - 0.5 * x - 0.1 * y);
+        let row = |address: &str, node: &str, cd: f64| crate::overland::CouplingRow {
+            address: address.into(),
+            node: node.into(),
+            cd,
+            area: 1.0,
+            area_authored: false,
+        };
+        // Vertex 4 = (1, 1), interior: six incident cells.
+        mesh.vertex_couplings.push(row("4", "J1", 0.5));
+        mesh.vertex_couplings.push(row("4", "J1", 0.7)); // same vertex: last wins
+        mesh.cell_couplings.push(row("0", "J2", 0.65));
+        mesh.cell_couplings.push(row("3", "J1", 0.65)); // same node: same slot
+        let m = build(&mesh);
+        let pts = m.coupling_points();
+        assert_eq!(pts.len(), 3);
+        assert_eq!(pts[0].cd, 0.7, "last authored row wins");
+        // The collapse cell is the lowest-bed incident cell of vertex 4.
+        let topo = Topology::build(&mesh).expect("valid");
+        let v = &mesh.verts[4];
+        let lowest = (0..mesh.cells.len())
+            .filter(|&ci| mesh.cells[ci].v.contains(&4))
+            .min_by(|&a, &b| topo.centroid[a][2].total_cmp(&topo.centroid[b][2]))
+            .expect("incident");
+        assert_eq!(pts[0].cell as usize, lowest);
+        assert_eq!(pts[0].vertex, Some((v.x, v.y, v.z)));
+        assert_eq!(m.coupling_nodes(), ["J1", "J2"]);
+        assert_eq!(pts[0].node_slot, 0);
+        assert_eq!(pts[1].node_slot, 1);
+        assert_eq!(pts[2].node_slot, 0);
+    }
+
+    /// §15.6: a ponded surface drains through a coupling at the orifice
+    /// rate, the ledger closes exactly, and the conductance is live.
+    #[test]
+    fn a_pond_drains_through_a_coupling_at_the_orifice_rate() {
+        let mut mesh = grid(4, 4, 1.0, |_, _| 10.0);
+        fill_to_stage(&mut mesh, 10.5);
+        mesh.cell_couplings.push(crate::overland::CouplingRow {
+            address: "0".into(),
+            node: "J1".into(),
+            cd: 0.65,
+            area: 0.05,
+            area_authored: true,
+        });
+        let mut m = build(&mesh);
+        let v0 = m.storage();
+        m.set_node_drive(0, 8.0, 2.0, 10.0, 0.0);
+        assert!(m.coupling_conductance(0) > 0.0);
+        m.advance(1.0);
+        // First-second drain within 10% of the initial orifice rate
+        // (the local drawdown cone lowers the driving head a little).
+        let q0 = 0.65 * (2.0 * 0.05) * (2.0 * G).sqrt() * 2.5_f64.sqrt();
+        assert!(
+            (m.coupling_out / q0 - 1.0).abs() < 0.10,
+            "drained {} vs orifice {q0}",
+            m.coupling_out
+        );
+        assert_eq!(m.exchanged().len(), 1);
+        assert!((m.exchanged()[0] - m.coupling_out).abs() < 1e-12);
+        m.advance(119.0);
+        // Ledger identity, exactly; the pond is nearly gone.
+        assert!(
+            (v0 - m.storage() - m.coupling_out).abs() < 1e-9,
+            "ledger: {} drained, {} missing",
+            m.coupling_out,
+            v0 - m.storage()
+        );
+        assert_eq!(m.coupling_in, 0.0);
+        assert!(m.storage() < 0.05 * v0, "pond still holds {}", m.storage());
+    }
+
+    /// §15.6: a spill draws against the node's advance-wide ledger —
+    /// the same water cannot spill twice within one routing step.
+    #[test]
+    fn a_spill_cannot_draw_the_same_water_twice() {
+        let mut mesh = grid(4, 4, 1.0, |_, _| 10.0);
+        mesh.cell_couplings.push(crate::overland::CouplingRow {
+            address: "0".into(),
+            node: "J1".into(),
+            cd: 0.65,
+            area: 0.05,
+            area_authored: true,
+        });
+        let mut m = build(&mesh);
+        m.set_node_drive(0, 11.0, 1.0, 10.0, 0.05);
+        m.advance(10.0);
+        assert!(
+            (m.coupling_in - 0.05).abs() < 1e-12,
+            "spilled {}",
+            m.coupling_in
+        );
+        assert!((m.storage() - 0.05).abs() < 1e-12);
+        // A further advance re-arms the budget.
+        m.set_node_drive(0, 11.0, 1.0, 10.0, 0.05);
+        m.advance(10.0);
+        assert!((m.coupling_in - 0.10).abs() < 1e-12);
+    }
+
+    /// §15.6: equal heads exchange nothing and leave the basin at rest.
+    #[test]
+    fn equal_heads_exchange_nothing() {
+        let mut mesh = grid(3, 3, 1.0, |_, _| 10.0);
+        fill_to_stage(&mut mesh, 10.5);
+        mesh.cell_couplings.push(crate::overland::CouplingRow {
+            address: "0".into(),
+            node: "J1".into(),
+            cd: 0.65,
+            area: 1.0,
+            area_authored: true,
+        });
+        let mut m = build(&mesh);
+        let v0 = m.storage();
+        m.set_node_drive(0, 10.5, 0.5, 10.0, 1.0);
+        m.advance(30.0);
+        assert_eq!(m.coupling_out, 0.0);
+        assert_eq!(m.coupling_in, 0.0);
+        assert!((m.storage() - v0).abs() < 1e-12);
+    }
+
+    /// §15.6: outfall injection scatters down the surface slope from
+    /// the vertex, and falls back to area weights on a flat surface.
+    #[test]
+    fn injection_scatters_downhill_from_the_vertex() {
+        let row = |address: &str| crate::overland::CouplingRow {
+            address: address.into(),
+            node: "OUT".into(),
+            cd: 0.65,
+            area: 1.0,
+            area_authored: true,
+        };
+        // Sloped and dry: η_v is the vertex ground elevation, cells
+        // downhill of it weight positive, uphill cells get nothing.
+        let mut mesh = grid(2, 2, 1.0, |x, _| 10.0 - 0.5 * x);
+        mesh.vertex_couplings.push(row("4")); // (1, 1), z = 9.5
+        let mut m = build(&mesh);
+        m.inject(0, 0.1);
+        let total: f64 = m.coupling.iter().zip(&m.area).map(|(r, a)| r * a).sum();
+        assert!((total - 0.1).abs() < 1e-12, "scatter conserves the rate");
+        let topo = Topology::build(&mesh).expect("valid");
+        for (ci, r) in m.coupling.iter().enumerate() {
+            if *r > 0.0 {
+                assert!(
+                    topo.centroid[ci][2] < 9.5,
+                    "cell {ci} is not downhill of the vertex"
+                );
+            }
+        }
+        // Flat: area weights over the whole stencil.
+        let mut mesh = grid(2, 2, 1.0, |_, _| 10.0);
+        mesh.vertex_couplings.push(row("4"));
+        let mut m = build(&mesh);
+        m.inject(0, 0.1);
+        let stencil: Vec<usize> = (0..mesh.cells.len())
+            .filter(|&ci| mesh.cells[ci].v.contains(&4))
+            .collect();
+        let asum: f64 = stencil.iter().map(|&ci| m.area[ci]).sum();
+        for &ci in &stencil {
+            assert!((m.coupling[ci] - 0.1 / asum).abs() < 1e-12);
+        }
+        m.clear_injection();
+        assert!(m.coupling.iter().all(|&r| r == 0.0));
     }
 
     /// §15.5: a stage boundary fills a dry basin toward its stage and

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -128,7 +128,12 @@ pub struct Marcher {
     /// §15.4.4 active set with hysteresis, one-ring halo, and pinned
     /// boundary cells.
     active: Vec<bool>,
-    substep: u64,
+    /// §15.4.4 tier per cell (0 = every base substep); boundary cells
+    /// pinned to 0, inactive cells parked at the coarsest.
+    tier: Vec<u8>,
+    /// A face fires at the finer of its two cells' cadences.
+    face_tier: Vec<u8>,
+    macro_cycles: u64,
 
     // ── Sources, set by the caller before an advance (m/s) ─────────
     pub rain: Vec<f64>,
@@ -306,7 +311,9 @@ impl Marcher {
             facc_l: vec![0.0; nf],
             facc_r: vec![0.0; nf],
             active: vec![false; nc],
-            substep: 0,
+            tier: vec![0; nc],
+            face_tier: Vec::new(),
+            macro_cycles: 0,
             rain: vec![0.0; nc],
             evap: vec![0.0; nc],
             coupling: vec![0.0; nc],
@@ -318,6 +325,7 @@ impl Marcher {
         for ci in 0..nc {
             m.reclose(ci);
         }
+        m.face_tier = vec![0; m.faces.len()];
         m.refresh_perot();
         m.rebuild_active();
         m
@@ -340,21 +348,30 @@ impl Marcher {
     /// the march (waves growing from the θ-blend feeding on itself).
     fn refresh_perot(&mut self) {
         for ci in 0..self.area.len() {
-            let (mut sx, mut sy) = (0.0, 0.0);
-            let lo = self.cf_off[ci] as usize;
-            let hi = self.cf_off[ci + 1] as usize;
-            for &(fi, sign) in &self.cf_face[lo..hi] {
-                let f = &self.faces[fi as usize];
-                let flux = sign * self.q[fi as usize] * f.xi;
-                sx += flux * (f.mx - self.cx[ci]);
-                sy += flux * (f.my - self.cy[ci]);
-            }
-            self.qcx[ci] = sx / self.area[ci];
-            self.qcy[ci] = sy / self.area[ci];
+            self.perot_cell(ci);
         }
-        // §15.5 completion: a boundary edge's discharge belongs to its
-        // cell's reconstruction too, in the same outward-flux convention
-        // (the prognostic is inflow-positive, so outward is its negation).
+        self.perot_complete_boundaries();
+    }
+
+    /// One cell's interior-face reconstruction, at its firing.
+    fn perot_cell(&mut self, ci: usize) {
+        let (mut sx, mut sy) = (0.0, 0.0);
+        let lo = self.cf_off[ci] as usize;
+        let hi = self.cf_off[ci + 1] as usize;
+        for &(fi, sign) in &self.cf_face[lo..hi] {
+            let f = &self.faces[fi as usize];
+            let flux = sign * self.q[fi as usize] * f.xi;
+            sx += flux * (f.mx - self.cx[ci]);
+            sy += flux * (f.my - self.cy[ci]);
+        }
+        self.qcx[ci] = sx / self.area[ci];
+        self.qcy[ci] = sy / self.area[ci];
+    }
+
+    /// §15.5 completion: a boundary edge's discharge belongs to its
+    /// cell's reconstruction too, in the same outward-flux convention
+    /// (the prognostic is inflow-positive, so outward is its negation).
+    fn perot_complete_boundaries(&mut self) {
         for b in &self.boundaries {
             let ci = b.cell as usize;
             let flux = -b.q * b.xi;
@@ -391,26 +408,109 @@ impl Marcher {
         self.active = next;
     }
 
-    /// §15.4.4: the stable step over active cells.
-    fn stable_dt(&self) -> f64 {
-        let mut dt = self.max_dt;
-        for ci in 0..self.area.len() {
-            if !self.active[ci] || self.depth[ci] <= self.dry_depth {
-                continue;
-            }
-            let h = self.depth[ci];
-            let speed = (G * h).sqrt() + (self.qcx[ci].hypot(self.qcy[ci])) / h;
-            if self.metric[ci] > 0.0 && speed > 0.0 {
-                let l = (2.0 * self.area[ci] / self.metric[ci]).sqrt();
-                dt = dt.min(self.cfl * l / speed);
-            }
+    /// §15.4.4: a cell's stable step, `max_dt` where no wave constrains.
+    fn cell_dt(&self, ci: usize) -> f64 {
+        if !self.active[ci] || self.depth[ci] <= self.dry_depth {
+            return self.max_dt;
         }
-        dt
+        let h = self.depth[ci];
+        let speed = (G * h).sqrt() + (self.qcx[ci].hypot(self.qcy[ci])) / h;
+        if self.metric[ci] > 0.0 && speed > 0.0 {
+            let l = (2.0 * self.area[ci] / self.metric[ci]).sqrt();
+            (self.cfl * l / speed).min(self.max_dt)
+        } else {
+            self.max_dt
+        }
     }
 
-    /// §15.4.2 ∥ face phase (serial in this slice; per-face writes only).
-    fn fire_faces(&mut self, dt: f64) {
+    /// §15.4.4: the stable base step over active cells.
+    fn stable_dt(&self) -> f64 {
+        (0..self.area.len())
+            .map(|ci| self.cell_dt(ci))
+            .fold(self.max_dt, f64::min)
+    }
+
+    /// §15.4.4 published picture: the observable discharge of face
+    /// `fi`, re-limited against the published surfaces — dry faces read
+    /// zero and the Froude cap is re-applied. The prognostic value is
+    /// untouched.
+    pub fn published_face_q(&self, fi: usize) -> f64 {
+        let f = &self.faces[fi];
+        let (cl, cr) = (f.cl as usize, f.cr as usize);
+        let h_f = match self.face_rec {
+            FaceReconstruction::Mean => face_depth_mean(self.eta[cl], self.eta[cr], f.z_face),
+            FaceReconstruction::VfrFace => {
+                face_depth_vfr(self.eta[cl], self.eta[cr], f.z_lo, f.z_hi)
+            }
+        };
+        if h_f <= self.dry_depth {
+            return 0.0;
+        }
+        let cap = self.froude_max * h_f * (G * h_f).sqrt();
+        self.q[fi].clamp(-cap, cap)
+    }
+
+    /// §15.4.4: re-tiering invalidates the positivity bookkeeping of
+    /// in-flight accumulators, so gather every pending side into its
+    /// cell first, and re-close the cells that changed.
+    fn settle_accumulators(&mut self) {
+        for ci in 0..self.area.len() {
+            let lo = self.cf_off[ci] as usize;
+            let hi = self.cf_off[ci + 1] as usize;
+            let mut pending = 0.0;
+            for &(fi, sign) in &self.cf_face[lo..hi] {
+                let fi = fi as usize;
+                if sign > 0.0 {
+                    pending += self.facc_l[fi];
+                    self.facc_l[fi] = 0.0;
+                } else {
+                    pending += self.facc_r[fi];
+                    self.facc_r[fi] = 0.0;
+                }
+            }
+            if pending != 0.0 {
+                self.vol[ci] = (self.vol[ci] + pending).max(0.0);
+                self.reclose(ci);
+            }
+        }
+    }
+
+    /// §15.4.4: assign every cell its power-of-two tier from its own
+    /// stable step against the base step; boundary cells pin to 0,
+    /// inactive cells park at the coarsest; a face takes the finer of
+    /// its two cells' cadences.
+    fn assign_tiers(&mut self, dt0: f64) {
+        let k_max = self.lts_tiers.saturating_sub(1).min(7) as u8;
+        for ci in 0..self.area.len() {
+            self.tier[ci] = if !self.active[ci] {
+                k_max
+            } else {
+                let ratio = (self.cell_dt(ci) / dt0).max(1.0);
+                (ratio.log2().floor() as u8).min(k_max)
+            };
+        }
+        for b in &self.boundaries {
+            self.tier[b.cell as usize] = 0;
+        }
+        for (fi, f) in self.faces.iter().enumerate() {
+            self.face_tier[fi] = self.tier[f.cl as usize].min(self.tier[f.cr as usize]);
+            // §15.4.4: a face walled by deactivation surrenders its
+            // discharge; stale momentum must not survive re-activation.
+            if !(self.active[f.cl as usize] && self.active[f.cr as usize]) {
+                self.q[fi] = 0.0;
+            }
+        }
+    }
+
+    /// §15.4.2 ∥ face phase (serial in this slice; per-face writes
+    /// only): fire every face whose tier is due at base substep `s`,
+    /// each over its own tier's interval.
+    fn fire_faces(&mut self, dt0: f64, s: u64) {
         for fi in 0..self.faces.len() {
+            if !s.is_multiple_of(1u64 << self.face_tier[fi]) {
+                continue;
+            }
+            let dt = dt0 * f64::from(1u32 << self.face_tier[fi]);
             let f = &self.faces[fi];
             let (cl, cr) = (f.cl as usize, f.cr as usize);
             // Both-active gating: a one-sided face loses basin volume.
@@ -445,9 +545,13 @@ impl Marcher {
             let q_cap = self.froude_max * h_f * (G * h_f).sqrt();
             q_new = q_new.clamp(-q_cap, q_cap);
             // Positivity: the exporter grants at most β/3 of its volume
-            // per cell cycle.
+            // per cell cycle, divided by the times this face fires
+            // within the exporter's cycle (§15.4.4) — repeated takes at
+            // a tier interface would otherwise drain the cell into the
+            // backstop.
             let exporter = if q_new > 0.0 { cl } else { cr };
-            let budget = BETA / 3.0 * self.vol[exporter].max(0.0);
+            let refire = 1u32 << (self.tier[exporter] - self.face_tier[fi]);
+            let budget = BETA / 3.0 / f64::from(refire) * self.vol[exporter].max(0.0);
             let take = q_new.abs() * f.psi * f.xi * dt;
             if take > budget && take > 0.0 {
                 q_new *= budget / take;
@@ -459,10 +563,16 @@ impl Marcher {
         }
     }
 
-    /// §15.4.3 ∥ cell phase: gather own sides in fixed order, apply
-    /// sources, clamp, re-close.
-    fn fire_cells(&mut self, dt: f64) {
+    /// §15.4.3 ∥ cell phase: every cell whose tier is due at base
+    /// substep `s` gathers its own accumulator sides in fixed order,
+    /// applies its sources over its own tier's interval, clamps,
+    /// re-closes, and refreshes its velocity reconstruction.
+    fn fire_cells(&mut self, dt0: f64, s: u64) {
         for ci in 0..self.area.len() {
+            if !s.is_multiple_of(1u64 << self.tier[ci]) {
+                continue;
+            }
+            let dt = dt0 * f64::from(1u32 << self.tier[ci]);
             let lo = self.cf_off[ci] as usize;
             let hi = self.cf_off[ci + 1] as usize;
             let mut flux = 0.0;
@@ -490,6 +600,7 @@ impl Marcher {
             self.evap_out += take;
             self.vol[ci] = (before - take).max(0.0);
             self.reclose(ci);
+            self.perot_cell(ci);
         }
     }
 
@@ -576,32 +687,58 @@ impl Marcher {
             }
             self.vol[ci] = v_new;
             self.reclose(ci);
+            self.perot_cell(ci);
         }
+        self.perot_complete_boundaries();
     }
 
     /// Advance to exactly `span` seconds from now (§15.4.4: an advance
     /// always reaches its target).
     pub fn advance(&mut self, span: f64) {
         let mut remaining = span;
-        // Rebuild cadence: every fourth macro cycle of the (future) tier
-        // ladder — with the single-tier march, every 4·2^(K−1) substeps.
-        let rebuild_every = 4u64 << (self.lts_tiers.saturating_sub(1));
+        let nsub = 1u64 << self.lts_tiers.saturating_sub(1).min(7);
         let mut dt0 = self.stable_dt();
         while remaining > 1e-12 {
-            if self.substep.is_multiple_of(rebuild_every) {
+            // §15.4.4: the active set and the tiers rebuild every fourth
+            // macro cycle; between rebuilds the base step may only
+            // tighten, at macro-cycle boundaries, so every firing within
+            // a cycle shares one consistent dt0 and every cell
+            // integrates exactly nsub·dt0 per cycle.
+            if self.macro_cycles.is_multiple_of(4) {
+                self.settle_accumulators();
                 self.rebuild_active();
                 dt0 = self.stable_dt();
+                self.assign_tiers(dt0);
             } else {
-                // Between rebuilds the step may only tighten.
                 dt0 = dt0.min(self.stable_dt());
             }
-            let dt = dt0.min(remaining);
-            self.fire_faces(dt);
-            self.fire_cells(dt);
-            self.fire_boundaries(dt);
-            self.refresh_perot();
-            self.substep += 1;
-            remaining -= dt;
+            if dt0 * nsub as f64 > remaining {
+                // Tail: collapse every cell to tier 0 and land exactly.
+                // The collapse is a re-tiering, so settle first (§15.4.4).
+                self.settle_accumulators();
+                for t in &mut self.tier {
+                    *t = 0;
+                }
+                for t in &mut self.face_tier {
+                    *t = 0;
+                }
+                while remaining > 1e-12 {
+                    let dt = dt0.min(remaining);
+                    self.fire_faces(dt, 0);
+                    self.fire_cells(dt, 0);
+                    self.fire_boundaries(dt);
+                    remaining -= dt;
+                }
+                self.macro_cycles += 1;
+                break;
+            }
+            for s in 0..nsub {
+                self.fire_faces(dt0, s);
+                self.fire_cells(dt0, s);
+                self.fire_boundaries(dt0);
+            }
+            remaining -= dt0 * nsub as f64;
+            self.macro_cycles += 1;
         }
     }
 
@@ -846,6 +983,390 @@ mod tests {
         assert!(
             (h_avg / h_n - 1.0).abs() < 0.06,
             "mid-strip depth {h_avg} vs normal {h_n}"
+        );
+    }
+
+    /// A geometrically graded strip: cell sizes span a decade, so the
+    /// tier ladder genuinely spreads. `ratio` grades each quad's width.
+    fn graded_strip(nx: usize, ny: usize, dx0: f64, ratio: f64) -> OverlandMesh {
+        let mut mesh = OverlandMesh::default();
+        let mut xs = vec![0.0];
+        let mut dx = dx0;
+        for _ in 0..nx {
+            xs.push(xs.last().unwrap() + dx);
+            dx *= ratio;
+        }
+        let nvx = nx + 1;
+        for j in 0..=ny {
+            for &x in &xs {
+                mesh.verts.push(MeshVertex {
+                    x,
+                    y: j as f64,
+                    z: 10.0,
+                    tag: None,
+                });
+            }
+        }
+        for j in 0..ny {
+            for i in 0..nx {
+                let v00 = (j * nvx + i) as u32;
+                let v10 = (j * nvx + i + 1) as u32;
+                let v01 = ((j + 1) * nvx + i) as u32;
+                let v11 = ((j + 1) * nvx + i + 1) as u32;
+                mesh.cells.push(MeshCell {
+                    v: [v00, v10, v11],
+                    n: 0.10,
+                    h0: 0.0,
+                    tag: None,
+                });
+                mesh.cells.push(MeshCell {
+                    v: [v00, v11, v01],
+                    n: 0.10,
+                    h0: 0.0,
+                    tag: None,
+                });
+            }
+        }
+        mesh
+    }
+
+    /// The graded dam break at K tiers: 1.5 m charged over the fine end,
+    /// fronts crossing every tier interface. Returns (volumes at t_mid,
+    /// time-mean volumes over the last window, relative volume drift).
+    fn graded_dam_break(k: u32, t_mid: f64, t_end: f64) -> (Vec<f64>, Vec<f64>, f64) {
+        let mut mesh = graded_strip(24, 4, 1.0, 1.08);
+        mesh.options.lts_tiers = k;
+        let topo = Topology::build(&mesh).expect("valid");
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .enumerate()
+            .map(|(ci, mut c)| {
+                if topo.centroid[ci][0] < 4.0 {
+                    c.h0 = 1.5;
+                }
+                c
+            })
+            .collect();
+        let mut m = build(&mesh);
+        let v0 = m.storage();
+        let mut t = 0.0;
+        while t < t_mid {
+            m.advance(5.0f64.min(t_mid - t));
+            t += 5.0;
+        }
+        let v_mid = m.vol.clone();
+        // Time-mean over the last 60 s: the closed basin sustains a
+        // weakly damped seiche, and an instantaneous sample aliases the
+        // K-dependent phase; the mean is the settled solution.
+        let mut acc = vec![0.0; m.vol.len()];
+        let mut n_samples = 0u32;
+        while t < t_end {
+            m.advance(5.0f64.min(t_end - t));
+            t += 5.0;
+            if t >= t_end - 60.0 {
+                for (a, v) in acc.iter_mut().zip(&m.vol) {
+                    *a += v;
+                }
+                n_samples += 1;
+            }
+        }
+        for a in &mut acc {
+            *a /= f64::from(n_samples);
+        }
+        let drift = ((m.storage() - v0) / v0).abs();
+        (v_mid, acc, drift)
+    }
+
+    /// §15.9: the march conserves exactly at every tier count, through a
+    /// multiscale dam break with fronts crossing tier interfaces.
+    #[test]
+    fn lts_conserves_at_every_tier_count() {
+        for k in [1u32, 2, 4, 6] {
+            let (_, _, drift) = graded_dam_break(k, 60.0, 120.0);
+            assert!(drift < 1e-10, "volume drift {drift} at K={k}");
+        }
+    }
+
+    /// §15.9: the tiered march agrees with the global-step march — the
+    /// mid-transient divergence decays rather than grows, and the
+    /// settled solutions match to centimetres.
+    #[test]
+    fn lts_agrees_with_the_global_step() {
+        let (mid1, end1, _) = graded_dam_break(1, 120.0, 600.0);
+        let (mid4, end4, _) = graded_dam_break(4, 120.0, 600.0);
+        let mesh = graded_strip(24, 4, 1.0, 1.08);
+        let topo = Topology::build(&mesh).expect("valid");
+        let depth_div = |a: &[f64], b: &[f64]| {
+            a.iter()
+                .zip(b)
+                .enumerate()
+                .map(|(ci, (x, y))| (x - y).abs() / topo.area[ci])
+                .fold(0.0_f64, f64::max)
+        };
+        let max_mid = depth_div(&mid1, &mid4);
+        let max_end = depth_div(&end1, &end4);
+        assert!(
+            max_end < max_mid,
+            "tier divergence must decay, not grow: mid {max_mid} end {max_end}"
+        );
+        assert!(max_end <= 0.025, "settled max depth divergence {max_end}");
+        // Peak settled depths agree within 5%.
+        let peak = |v: &[f64]| {
+            v.iter()
+                .enumerate()
+                .map(|(ci, x)| x / topo.area[ci])
+                .fold(0.0_f64, f64::max)
+        };
+        let (p1, p4) = (peak(&end1), peak(&end4));
+        assert!(
+            (p4 - p1).abs() <= 0.05 * p1.max(1e-12),
+            "peaks: global {p1} tiered {p4}"
+        );
+    }
+
+    /// §15.4.2: at steady state the free surface is spatially smooth —
+    /// no standing cell-to-cell stair from the split-quad centroid
+    /// staggering. Guards the shared-edge sill datum, both closures.
+    #[test]
+    fn a_steady_slope_carries_no_checkerboard() {
+        for closure in [CellClosure::Flat, CellClosure::Vfr] {
+            let (nx, ny, dx, slope) = (40usize, 4usize, 1.0, 0.01);
+            let mut mesh = grid(nx, ny, dx, |x, _| 10.0 + slope * x);
+            mesh.options.cell_closure = closure;
+            let topo = Topology::build(&mesh).expect("valid");
+            for ci in 0..mesh.cells.len() {
+                for e in 0..3usize {
+                    let slot = ci * 3 + e;
+                    if topo.neighbour[slot].is_none() && topo.edge_mid[slot][0] < 1e-9 {
+                        mesh.boundaries.push(crate::overland::BoundaryRow {
+                            cell: ci as u32,
+                            edge: e as u8,
+                            condition: BoundaryCondition::NormalFlow { slope },
+                            group: None,
+                        });
+                    }
+                }
+            }
+            let mut m = build(&mesh);
+            for r in &mut m.rain {
+                *r = 2.0e-4;
+            }
+            m.advance(6000.0);
+            // Roughness of η against the face-neighbour mean over the
+            // strip interior (the outlet drawdown and the upslope crest
+            // carry genuine one-sided curvature).
+            let (mut ss, mut mx, mut n) = (0.0_f64, 0.0_f64, 0u32);
+            for ci in 0..m.eta.len() {
+                let x = topo.centroid[ci][0];
+                if !(5.0..=35.0).contains(&x) {
+                    continue;
+                }
+                let (mut hs, mut hn) = (0.0, 0u32);
+                for e in 0..3usize {
+                    if let Some(nb) = topo.neighbour[ci * 3 + e] {
+                        hs += m.eta[nb as usize];
+                        hn += 1;
+                    }
+                }
+                if hn < 3 {
+                    continue;
+                }
+                let r = m.eta[ci] - hs / f64::from(hn);
+                ss += r * r;
+                mx = mx.max(r.abs());
+                n += 1;
+            }
+            let rms = (ss / f64::from(n.max(1))).sqrt();
+            assert!(rms < 1.2e-3, "{closure:?}: surface roughness rms {rms}");
+            assert!(mx < 3.5e-3, "{closure:?}: surface roughness max {mx}");
+        }
+    }
+
+    /// §15.4.2: on a steep dam-break every published face discharge obeys
+    /// the Froude cap against the clamp's own face depth, and nothing
+    /// runs away.
+    #[test]
+    fn the_froude_clamp_bounds_every_face() {
+        let mut mesh = grid(20, 3, 1.0, |x, _| 10.0 - 0.10 * x);
+        let topo = Topology::build(&mesh).expect("valid");
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .enumerate()
+            .map(|(ci, mut c)| {
+                c.n = 0.015;
+                if topo.centroid[ci][0] < 3.0 {
+                    c.h0 = 1.0;
+                }
+                c
+            })
+            .collect();
+        let mut m = build(&mesh);
+        for _ in 0..40 {
+            m.advance(1.0);
+            for &v in &m.vol {
+                assert!(v.is_finite());
+            }
+            for (fi, f) in m.faces.iter().enumerate() {
+                let q = m.published_face_q(fi).abs();
+                if q == 0.0 {
+                    continue;
+                }
+                let h_f = m.eta[f.cl as usize].max(m.eta[f.cr as usize]) - f.z_face;
+                assert!(h_f > 0.0, "published flux across a dry face");
+                let cap = m.froude_max * h_f * (G * h_f).sqrt();
+                assert!(q <= cap * (1.0 + 1e-9), "face {fi}: {q} above cap {cap}");
+            }
+        }
+    }
+
+    /// §15.3: a one-vertex-wide ridge holds a pool under `VFR_FACE` (the
+    /// edge's own endpoint beds wall it) and leaks under `MEAN` (the
+    /// centroid-diluted face bed conveys) — the documented defect the
+    /// option exists to fix.
+    #[test]
+    fn a_thin_crest_holds_under_vfr_face_and_leaks_under_mean() {
+        let ridge = |x: f64, _: f64| if (x - 8.0).abs() < 1e-9 { 1.0 } else { 0.0 };
+        let seed = |rec: FaceReconstruction| {
+            let mut mesh = grid(8, 4, 2.0, ridge);
+            mesh.options.face_reconstruction = rec;
+            fill_to_stage(&mut mesh, 0.9);
+            let topo = Topology::build(&mesh).expect("valid");
+            let cells = std::mem::take(&mut mesh.cells);
+            mesh.cells = cells
+                .into_iter()
+                .enumerate()
+                .map(|(ci, mut c)| {
+                    if topo.centroid[ci][0] > 8.0 {
+                        c.h0 = 0.0;
+                    }
+                    c
+                })
+                .collect();
+            (build(&mesh), topo)
+        };
+
+        // VFR_FACE walls the crest: the right half stays bone dry and the
+        // pool keeps its volume.
+        let (mut m, topo) = seed(FaceReconstruction::VfrFace);
+        let v0 = m.vol.clone();
+        m.advance(600.0);
+        for (ci, (&v, &v_init)) in m.vol.iter().zip(&v0).enumerate() {
+            if topo.centroid[ci][0] > 8.0 {
+                assert_eq!(v, 0.0, "VFR_FACE leaked at cell {ci}");
+            } else {
+                assert!(
+                    (v - v_init).abs() <= 1e-9 * (v_init + 1.0),
+                    "pool cell {ci} moved: {v} vs {v_init}"
+                );
+            }
+        }
+
+        // MEAN leaks through the centroid-diluted crest.
+        let (mut m, topo) = seed(FaceReconstruction::Mean);
+        m.advance(600.0);
+        let crossed: f64 = (0..m.vol.len())
+            .filter(|&ci| topo.centroid[ci][0] > 8.0)
+            .map(|ci| m.vol[ci])
+            .sum();
+        assert!(crossed > 0.0, "expected the centroid face bed to leak");
+    }
+
+    /// §15.9 SWASHES: subcritical flow over a bump, against the exact
+    /// Bernoulli cubic. The scheme omits convective acceleration, so its
+    /// frictionless steady surface is flat and the residual is exactly
+    /// the velocity-head dip over the bump; the grade bounds the
+    /// relative L1 depth error at 1.5%.
+    #[test]
+    fn swashes_subcritical_flow_over_a_bump() {
+        let (nx, ny, dx) = (100usize, 2usize, 0.25);
+        let l = nx as f64 * dx;
+        let (q_in, h_out) = (4.42, 2.0);
+        let bump = |x: f64, _: f64| {
+            if x > 8.0 && x < 12.0 {
+                0.2 - 0.05 * (x - 10.0) * (x - 10.0)
+            } else {
+                0.0
+            }
+        };
+        let mut mesh = grid(nx, ny, dx, bump);
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .map(|mut c| {
+                c.n = 1e-6; // the case is frictionless
+                c
+            })
+            .collect();
+        fill_to_stage(&mut mesh, h_out);
+        let topo = Topology::build(&mesh).expect("valid");
+        for ci in 0..mesh.cells.len() {
+            for e in 0..3usize {
+                let slot = ci * 3 + e;
+                if topo.neighbour[slot].is_some() {
+                    continue;
+                }
+                let x = topo.edge_mid[slot][0];
+                if x < 1e-9 {
+                    // Inflow: authored outward-positive, so inflow is
+                    // negative (§15.5).
+                    mesh.boundaries.push(crate::overland::BoundaryRow {
+                        cell: ci as u32,
+                        edge: e as u8,
+                        condition: BoundaryCondition::Flow(SeriesOrValue::Value(-q_in)),
+                        group: None,
+                    });
+                } else if x > l - 1e-9 {
+                    mesh.boundaries.push(crate::overland::BoundaryRow {
+                        cell: ci as u32,
+                        edge: e as u8,
+                        condition: BoundaryCondition::Stage(SeriesOrValue::Value(h_out)),
+                        group: None,
+                    });
+                }
+            }
+        }
+        let mut m = build(&mesh);
+        // §15.9: between a specified-flow inlet and a stage outlet the
+        // frictionless case holds an undamped standing wave; the grade
+        // reads the time-mean field, which is the steady solution.
+        m.advance(300.0);
+        let mut mean = vec![0.0; m.depth.len()];
+        let samples = 300u32;
+        for _ in 0..samples {
+            m.advance(1.0);
+            for (a, h) in mean.iter_mut().zip(&m.depth) {
+                *a += h;
+            }
+        }
+        for a in &mut mean {
+            *a /= f64::from(samples);
+        }
+
+        // The exact profile: h³ + (z − H)h² + q²/2g = 0, subcritical
+        // root, H the outlet's total head.
+        let head = h_out + q_in * q_in / (2.0 * G * h_out * h_out);
+        let exact = |z: f64| {
+            let mut h = (head - z).max(0.1);
+            for _ in 0..60 {
+                let f = h * h * h + (z - head) * h * h + q_in * q_in / (2.0 * G);
+                let df = 3.0 * h * h + 2.0 * (z - head) * h;
+                h -= f / df;
+            }
+            h
+        };
+        let (mut err, mut norm) = (0.0, 0.0);
+        for (ci, &h) in mean.iter().enumerate() {
+            let x = topo.centroid[ci][0];
+            let h_ref = exact(bump(x, 0.0));
+            err += (h - h_ref).abs() * topo.area[ci];
+            norm += h_ref * topo.area[ci];
+        }
+        assert!(
+            err / norm < 0.0125,
+            "SWASHES bump relative L1 depth error {}",
+            err / norm
         );
     }
 

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -1180,6 +1180,8 @@ impl Marcher {
             fr: fr.as_mut_ptr(),
             led: led.as_mut_ptr(),
         };
+        // `mut` only when the team path can set it.
+        #[cfg_attr(not(feature = "threads"), allow(unused_mut))]
         let mut ran = false;
         #[cfg(feature = "threads")]
         {

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -146,6 +146,14 @@ pub struct Marcher {
     /// A face fires at the finer of its two cells' cadences.
     face_tier: Vec<u8>,
     macro_cycles: u64,
+    /// §15.4.4 whole-run counts for the §14.9 time-step summary.
+    substeps: u64,
+    rebuilds: u64,
+    min_dt0: f64,
+    advanced: f64,
+    peak_active: usize,
+    /// Initial storage (m³), the §15.8 ledger's opening term.
+    storage0: f64,
 
     // ── Sources, set by the caller before an advance (m/s) ─────────
     pub rain: Vec<f64>,
@@ -485,6 +493,12 @@ impl Marcher {
             tier: vec![0; nc],
             face_tier: Vec::new(),
             macro_cycles: 0,
+            substeps: 0,
+            rebuilds: 0,
+            min_dt0: f64::INFINITY,
+            advanced: 0.0,
+            peak_active: 0,
+            storage0: 0.0,
             rain: vec![0.0; nc],
             evap: vec![0.0; nc],
             coupling: vec![0.0; nc],
@@ -515,6 +529,8 @@ impl Marcher {
         m.face_tier = vec![0; m.faces.len()];
         m.refresh_perot();
         m.rebuild_active();
+        m.rebuilds = 0;
+        m.storage0 = m.storage();
         m
     }
 
@@ -602,6 +618,8 @@ impl Marcher {
                 next[ci] = true;
             }
         }
+        self.rebuilds += 1;
+        self.peak_active = self.peak_active.max(next.iter().filter(|a| **a).count());
         self.active = next;
     }
 
@@ -1185,6 +1203,9 @@ impl Marcher {
                     self.fire_cells(dt, 0);
                     self.fire_boundaries(dt);
                     self.fire_couplings(dt);
+                    self.substeps += 1;
+                    self.min_dt0 = self.min_dt0.min(dt);
+                    self.advanced += dt;
                     remaining -= dt;
                 }
                 self.macro_cycles += 1;
@@ -1196,9 +1217,59 @@ impl Marcher {
                 self.fire_boundaries(dt0);
                 self.fire_couplings(dt0);
             }
+            self.substeps += nsub;
+            self.min_dt0 = self.min_dt0.min(dt0);
+            self.advanced += dt0 * nsub as f64;
             remaining -= dt0 * nsub as f64;
             self.macro_cycles += 1;
         }
+    }
+
+    /// §15.4.4 whole-run march counts for the §14.9 time-step summary:
+    /// (base substeps, macro cycles, active-set rebuilds, minimum base
+    /// step (s), average base step (s), peak active cells). The minimum
+    /// and average read zero before any substep has fired.
+    pub fn statistics(&self) -> (u64, u64, u64, f64, f64, usize) {
+        let min = if self.substeps == 0 {
+            0.0
+        } else {
+            self.min_dt0
+        };
+        let avg = if self.substeps == 0 {
+            0.0
+        } else {
+            self.advanced / self.substeps as f64
+        };
+        (
+            self.substeps,
+            self.macro_cycles,
+            self.rebuilds,
+            min,
+            avg,
+            self.peak_active,
+        )
+    }
+
+    /// A cell's §15.4.3 Perot flow proxy $\mathbf{q}_c$ (m²/s); its
+    /// velocity is this over the depth.
+    pub fn cell_velocity_proxy(&self, ci: usize) -> (f64, f64) {
+        (self.qcx[ci], self.qcy[ci])
+    }
+
+    /// The §15.8 ledger's opening storage (m³).
+    pub fn initial_storage(&self) -> f64 {
+        self.storage0
+    }
+
+    /// §15.8 continuity error as a signed volume (m³): storage now
+    /// against everything the ledger says arrived and left.
+    pub fn ledger_error(&self) -> f64 {
+        self.storage()
+            - (self.storage0 + self.rain_in + self.coupling_in + self.outfall_in + self.boundary_in
+                - self.evap_out
+                - self.coupling_out
+                - self.outfall_out
+                - self.boundary_out)
     }
 
     /// Total stored volume (m³), the conservation ledger's storage term.

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -136,19 +136,22 @@ pub struct Marcher {
     pub eta: Vec<f64>,
     /// Derived mean depths (m).
     pub depth: Vec<f64>,
-    /// Perot velocity proxies (m²/s).
-    qcx: Vec<f64>,
-    qcy: Vec<f64>,
-    /// Face discharges (m²/s) and pending mass per side (m³).
-    q: Vec<f64>,
-    facc_l: Vec<f64>,
-    facc_r: Vec<f64>,
+    /// Perot velocity proxies (m²/s); crate-visible for §12.3 — each
+    /// cell's is stale by design (its own last firing's), so a restore
+    /// carries them rather than recomputing against newer discharges.
+    pub(crate) qcx: Vec<f64>,
+    pub(crate) qcy: Vec<f64>,
+    /// Face discharges (m²/s) and pending mass per side (m³);
+    /// crate-visible for §12.3 checkpoint carriage.
+    pub(crate) q: Vec<f64>,
+    pub(crate) facc_l: Vec<f64>,
+    pub(crate) facc_r: Vec<f64>,
     /// §15.4.4 active set with hysteresis, one-ring halo, and pinned
     /// boundary cells.
-    active: Vec<bool>,
+    pub(crate) active: Vec<bool>,
     /// §15.4.4 tier per cell (0 = every base substep); boundary cells
     /// pinned to 0, inactive cells parked at the coarsest.
-    tier: Vec<u8>,
+    pub(crate) tier: Vec<u8>,
     /// A face fires at the finer of its two cells' cadences.
     face_tier: Vec<u8>,
     /// §15.4.4: the members of each tier, index-sorted — a substep
@@ -161,16 +164,16 @@ pub struct Marcher {
     active_list: Vec<u32>,
     /// §15.4.4: seconds of source integration owed to inactive cells
     /// since their last lazy sync.
-    lazy_owed: f64,
-    macro_cycles: u64,
+    pub(crate) lazy_owed: f64,
+    pub(crate) macro_cycles: u64,
     /// §15.4.4 whole-run counts for the §14.9 time-step summary.
-    substeps: u64,
-    rebuilds: u64,
-    min_dt0: f64,
-    advanced: f64,
-    peak_active: usize,
+    pub(crate) substeps: u64,
+    pub(crate) rebuilds: u64,
+    pub(crate) min_dt0: f64,
+    pub(crate) advanced: f64,
+    pub(crate) peak_active: usize,
     /// Initial storage (m³), the §15.8 ledger's opening term.
-    storage0: f64,
+    pub(crate) storage0: f64,
     /// Per-cell ledger scratch for the ∥ cell phase: (rain, coupling,
     /// evaporation take), reduced serially in index order so the sums
     /// are byte-identical at every width (§15.4.5).
@@ -789,6 +792,39 @@ impl Marcher {
     #[cfg(feature = "threads")]
     pub fn set_width(&mut self, width: usize) {
         self.team = crate::hydraulics::team::Team::new(width);
+    }
+
+    /// §12.3: the boundary laws' prognostic discharges, in slot order.
+    pub(crate) fn boundary_discharges(&self) -> Vec<f64> {
+        self.boundaries.iter().map(|b| b.q).collect()
+    }
+
+    /// §12.3: restore the boundary discharges saved by
+    /// [`Marcher::boundary_discharges`].
+    pub(crate) fn set_boundary_discharges(&mut self, q: &[f64]) {
+        for (b, &v) in self.boundaries.iter_mut().zip(q) {
+            b.q = v;
+        }
+    }
+
+    /// §12.3: rebuild everything derivable after a checkpoint restore —
+    /// the closures from the volumes, the reconstruction from the
+    /// discharges, the face cadences from the cell tiers, and the
+    /// active and tier lists from the flags.
+    pub(crate) fn rebuild_after_restore(&mut self) {
+        for ci in 0..self.area.len() {
+            self.reclose(ci);
+        }
+        for (fi, f) in self.faces.iter().enumerate() {
+            self.face_tier[fi] = self.tier[f.cl as usize].min(self.tier[f.cr as usize]);
+        }
+        self.active_list.clear();
+        for (ci, on) in self.active.iter().enumerate() {
+            if *on {
+                self.active_list.push(ci as u32);
+            }
+        }
+        self.rebuild_tier_lists();
     }
 
     /// The §15.4.4 drying depth (m), for callers keying wetness ramps.

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -1,0 +1,882 @@
+//! §15.4: the explicit local-inertial marcher.
+//!
+//! Faces fire first, cells second, boundaries at the owning cell's
+//! firing — every update a pure function of the last published state,
+//! every reduction folded in fixed order, so the march is deterministic
+//! and, when the §6.4 team takes the phases (a later slice),
+//! byte-identical at any width. This slice runs every cell on the global
+//! step; the power-of-two tiers of §15.4.4 layer on top without changing
+//! a value the single-tier march produces at the same steps.
+
+use super::closure::{face_depth_mean, face_depth_vfr, flat_eta, vfr_eta, CellBed};
+use super::{
+    BoundaryCondition, CellClosure, FaceReconstruction, OverlandMesh, SeriesOrValue, Topology,
+};
+
+/// §15.1: standard gravity (m/s²).
+const G: f64 = 9.80665;
+
+/// §15.4.2: closure round-off must not masquerade as slope (m).
+const ETA_DEADBAND: f64 = 1e-12;
+
+/// §15.4.2: the exporting cell's per-face volume share β.
+const BETA: f64 = 0.8;
+
+/// One interior face: a single prognostic discharge shared by two cells,
+/// oriented from the lower-indexed cell to the higher.
+#[derive(Debug, Clone)]
+struct Face {
+    cl: u32,
+    cr: u32,
+    /// Planimetric length ξ (m).
+    xi: f64,
+    /// Unit normal, oriented cl → cr.
+    nx: f64,
+    ny: f64,
+    /// Face bed: max of the two centroid beds (m).
+    z_face: f64,
+    /// Sorted endpoint beds (m).
+    z_lo: f64,
+    z_hi: f64,
+    /// Edge midpoint (m), for the Perot offset (§15.4.3).
+    mx: f64,
+    my: f64,
+    /// Inverse normal distance 1/dₙ (1/m).
+    inv_dn: f64,
+    /// Conveyance ψ.
+    psi: f64,
+    /// Mean Manning n squared.
+    n2: f64,
+}
+
+/// One boundary slot with a non-wall condition, evaluated serially at
+/// tier-0 cadence (§15.5).
+#[derive(Debug, Clone)]
+struct Boundary {
+    cell: u32,
+    xi: f64,
+    /// The §15.5 law, with its authored constant. Series and curve
+    /// parameters resolve to per-advance constants at the wiring layer;
+    /// the marcher sees only values.
+    law: BoundaryLaw,
+    /// Edge midpoint, for the Perot completion (§15.5).
+    mx: f64,
+    my: f64,
+    /// Ghost-arm inverse distance for the stage law: 3ξ/(2A).
+    inv_dn_ghost: f64,
+    /// Prognostic discharge of the stage law's inertial arm (m²/s,
+    /// inflow positive).
+    q: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum BoundaryLaw {
+    /// Manning outfall at the authored bed slope.
+    NormalFlow { slope: f64 },
+    /// Held per-metre discharge (m³/s per m, authored outward positive).
+    Flow { q_per_m: f64 },
+    /// Held stage (m).
+    Stage { eta: f64 },
+}
+
+/// The marcher: geometry frozen at build, state advanced by
+/// [`Marcher::advance`].
+pub struct Marcher {
+    // ── Geometry ────────────────────────────────────────────────────
+    area: Vec<f64>,
+    /// Cell centroids (m), for the Perot offset (§15.4.3).
+    cx: Vec<f64>,
+    cy: Vec<f64>,
+    bed: Vec<CellBed>,
+    z_mean: Vec<f64>,
+    n_cell: Vec<f64>,
+    faces: Vec<Face>,
+    /// Cell → incident interior faces, CSR, ascending face index: the
+    /// §15.4.3 fixed gather order. Sign +1 when the cell is `cl`.
+    cf_off: Vec<u32>,
+    cf_face: Vec<(u32, f64)>,
+    boundaries: Vec<Boundary>,
+    /// Σ ξ/dₙ over each cell's interior faces, the §15.4.4 L² metric.
+    metric: Vec<f64>,
+
+    // ── Options (§14.15) ────────────────────────────────────────────
+    theta: f64,
+    cfl: f64,
+    froude_max: f64,
+    dry_depth: f64,
+    h_move: f64,
+    max_dt: f64,
+    closure: CellClosure,
+    face_rec: FaceReconstruction,
+    vfr_eps: f64,
+    lts_tiers: u32,
+
+    // ── State ───────────────────────────────────────────────────────
+    /// Conserved volumes (m³).
+    pub vol: Vec<f64>,
+    /// Derived surface elevations (m).
+    pub eta: Vec<f64>,
+    /// Derived mean depths (m).
+    pub depth: Vec<f64>,
+    /// Perot velocity proxies (m²/s).
+    qcx: Vec<f64>,
+    qcy: Vec<f64>,
+    /// Face discharges (m²/s) and pending mass per side (m³).
+    q: Vec<f64>,
+    facc_l: Vec<f64>,
+    facc_r: Vec<f64>,
+    /// §15.4.4 active set with hysteresis, one-ring halo, and pinned
+    /// boundary cells.
+    active: Vec<bool>,
+    substep: u64,
+
+    // ── Sources, set by the caller before an advance (m/s) ─────────
+    pub rain: Vec<f64>,
+    pub evap: Vec<f64>,
+    pub coupling: Vec<f64>,
+
+    // ── §15.8 ledger (m³ since construction) ───────────────────────
+    pub rain_in: f64,
+    pub evap_out: f64,
+    pub boundary_in: f64,
+    pub boundary_out: f64,
+}
+
+impl Marcher {
+    /// Build from a validated mesh and its topology. Initial volumes come
+    /// from the authored depths, initial face discharges from the
+    /// authored velocities projected onto the face normals.
+    pub fn build(mesh: &OverlandMesh, topo: &Topology) -> Marcher {
+        let nc = mesh.cells.len();
+        let o = &mesh.options;
+
+        let bed: Vec<CellBed> = mesh
+            .cells
+            .iter()
+            .map(|c| {
+                let [a, b, d] = c.v.map(|v| mesh.verts[v as usize].z);
+                CellBed::new(a, b, d)
+            })
+            .collect();
+
+        // Interior faces, one per shared edge, from the lower-indexed
+        // side's slot (its normal already points cl → cr).
+        let mut faces = Vec::new();
+        for ci in 0..nc {
+            for e in 0..3 {
+                let slot = ci * 3 + e;
+                let Some(nj) = topo.neighbour[slot] else {
+                    continue;
+                };
+                if (nj as usize) < ci {
+                    continue;
+                }
+                let [nx, ny] = topo.edge_normal[slot];
+                faces.push(Face {
+                    cl: ci as u32,
+                    cr: nj,
+                    xi: topo.edge_len[slot],
+                    nx,
+                    ny,
+                    z_face: topo.centroid[ci][2].max(topo.centroid[nj as usize][2]),
+                    z_lo: topo.edge_z[slot][0],
+                    z_hi: topo.edge_z[slot][1],
+                    mx: topo.edge_mid[slot][0],
+                    my: topo.edge_mid[slot][1],
+                    inv_dn: topo.inv_dn[slot],
+                    psi: topo.conveyance[slot],
+                    n2: {
+                        let n = 0.5 * (mesh.cells[ci].n + mesh.cells[nj as usize].n);
+                        n * n
+                    },
+                });
+            }
+        }
+
+        // Cell → faces CSR in ascending face order.
+        let mut counts = vec![0u32; nc + 1];
+        for f in &faces {
+            counts[f.cl as usize + 1] += 1;
+            counts[f.cr as usize + 1] += 1;
+        }
+        for i in 0..nc {
+            counts[i + 1] += counts[i];
+        }
+        let mut cursor = counts.clone();
+        let mut cf_face = vec![(0u32, 0.0); *counts.last().unwrap_or(&0) as usize];
+        for (fi, f) in faces.iter().enumerate() {
+            cf_face[cursor[f.cl as usize] as usize] = (fi as u32, 1.0);
+            cursor[f.cl as usize] += 1;
+            cf_face[cursor[f.cr as usize] as usize] = (fi as u32, -1.0);
+            cursor[f.cr as usize] += 1;
+        }
+
+        let mut metric = vec![0.0; nc];
+        for f in &faces {
+            let m = f.xi * f.inv_dn;
+            metric[f.cl as usize] += m;
+            metric[f.cr as usize] += m;
+        }
+
+        // Boundary laws from the validated rows; walls stay implicit.
+        let mut boundaries = Vec::new();
+        for row in &mesh.boundaries {
+            let law = match &row.condition {
+                BoundaryCondition::Wall => continue,
+                BoundaryCondition::NormalFlow { slope } => {
+                    BoundaryLaw::NormalFlow { slope: *slope }
+                }
+                BoundaryCondition::Flow(SeriesOrValue::Value(v)) => {
+                    BoundaryLaw::Flow { q_per_m: *v }
+                }
+                BoundaryCondition::Stage(SeriesOrValue::Value(v)) => BoundaryLaw::Stage { eta: *v },
+                // Series and curves resolve to per-advance values at the
+                // wiring layer; until then the slot is a wall, which is
+                // the refusal-safe reading of an unresolved parameter.
+                BoundaryCondition::Flow(SeriesOrValue::Series(_))
+                | BoundaryCondition::Stage(SeriesOrValue::Series(_))
+                | BoundaryCondition::RatingCurve { .. } => continue,
+            };
+            let slot = row.cell as usize * 3 + row.edge as usize;
+            let xi = topo.edge_len[slot];
+            boundaries.push(Boundary {
+                cell: row.cell,
+                xi,
+                law,
+                mx: topo.edge_mid[slot][0],
+                my: topo.edge_mid[slot][1],
+                inv_dn_ghost: 3.0 * xi / (2.0 * topo.area[row.cell as usize]),
+                q: 0.0,
+            });
+        }
+
+        let area: Vec<f64> = topo.area.clone();
+        let vol: Vec<f64> = mesh
+            .cells
+            .iter()
+            .enumerate()
+            .map(|(ci, c)| c.h0 * area[ci])
+            .collect();
+
+        // Authored velocities → face discharges: the mean of the two
+        // incident cells' (h·u, h·v), projected on the face normal.
+        let mut hu = vec![(0.0, 0.0); nc];
+        for r in &mesh.init_velocity {
+            let h0 = mesh.cells[r.cell as usize].h0;
+            hu[r.cell as usize] = (h0 * r.u, h0 * r.v);
+        }
+        let q: Vec<f64> = faces
+            .iter()
+            .map(|f| {
+                let (ul, vl) = hu[f.cl as usize];
+                let (ur, vr) = hu[f.cr as usize];
+                0.5 * ((ul + ur) * f.nx + (vl + vr) * f.ny)
+            })
+            .collect();
+
+        let nf = faces.len();
+        let mut m = Marcher {
+            cx: topo.centroid.iter().map(|c| c[0]).collect(),
+            cy: topo.centroid.iter().map(|c| c[1]).collect(),
+            z_mean: bed.iter().map(CellBed::mean).collect(),
+            n_cell: mesh.cells.iter().map(|c| c.n).collect(),
+            area,
+            bed,
+            faces,
+            cf_off: counts,
+            cf_face,
+            boundaries,
+            metric,
+            theta: o.theta,
+            cfl: o.cfl_number,
+            froude_max: o.froude_max,
+            dry_depth: o.dry_depth,
+            h_move: o.h_move,
+            max_dt: o.max_timestep,
+            closure: o.cell_closure,
+            face_rec: o.face_reconstruction,
+            vfr_eps: o.vfr_min_wet_frac,
+            lts_tiers: o.lts_tiers,
+            vol,
+            eta: vec![0.0; nc],
+            depth: vec![0.0; nc],
+            qcx: vec![0.0; nc],
+            qcy: vec![0.0; nc],
+            q,
+            facc_l: vec![0.0; nf],
+            facc_r: vec![0.0; nf],
+            active: vec![false; nc],
+            substep: 0,
+            rain: vec![0.0; nc],
+            evap: vec![0.0; nc],
+            coupling: vec![0.0; nc],
+            rain_in: 0.0,
+            evap_out: 0.0,
+            boundary_in: 0.0,
+            boundary_out: 0.0,
+        };
+        for ci in 0..nc {
+            m.reclose(ci);
+        }
+        m.refresh_perot();
+        m.rebuild_active();
+        m
+    }
+
+    /// Re-derive a cell's surface from its volume (§15.3).
+    fn reclose(&mut self, ci: usize) {
+        let h = self.vol[ci].max(0.0) / self.area[ci];
+        self.depth[ci] = h;
+        self.eta[ci] = match self.closure {
+            CellClosure::Flat => flat_eta(&self.bed[ci], h),
+            CellClosure::Vfr => vfr_eta(&self.bed[ci], h, self.vfr_eps),
+        };
+    }
+
+    /// §15.4.3 Perot reconstruction over each cell's faces, fixed order:
+    /// $\mathbf{q}_c = \frac1A \sum_e s_e q_e \xi_e (\mathbf{m}_e -
+    /// \mathbf{c})$ — the midpoint offset, not the normal; the two differ
+    /// on any skewed cell, and the normal form was measured to destabilise
+    /// the march (waves growing from the θ-blend feeding on itself).
+    fn refresh_perot(&mut self) {
+        for ci in 0..self.area.len() {
+            let (mut sx, mut sy) = (0.0, 0.0);
+            let lo = self.cf_off[ci] as usize;
+            let hi = self.cf_off[ci + 1] as usize;
+            for &(fi, sign) in &self.cf_face[lo..hi] {
+                let f = &self.faces[fi as usize];
+                let flux = sign * self.q[fi as usize] * f.xi;
+                sx += flux * (f.mx - self.cx[ci]);
+                sy += flux * (f.my - self.cy[ci]);
+            }
+            self.qcx[ci] = sx / self.area[ci];
+            self.qcy[ci] = sy / self.area[ci];
+        }
+        // §15.5 completion: a boundary edge's discharge belongs to its
+        // cell's reconstruction too, in the same outward-flux convention
+        // (the prognostic is inflow-positive, so outward is its negation).
+        for b in &self.boundaries {
+            let ci = b.cell as usize;
+            let flux = -b.q * b.xi;
+            self.qcx[ci] += flux * (b.mx - self.cx[ci]) / self.area[ci];
+            self.qcy[ci] += flux * (b.my - self.cy[ci]) / self.area[ci];
+        }
+    }
+
+    /// §15.4.4 activation: hysteresis about `h_move`, a one-ring halo,
+    /// and boundary cells pinned.
+    fn rebuild_active(&mut self) {
+        let band = (0.001_f64).min(self.h_move / 2.0);
+        let core: Vec<bool> = (0..self.area.len())
+            .map(|ci| {
+                if self.active[ci] {
+                    self.depth[ci] >= self.h_move - band
+                } else {
+                    self.depth[ci] > self.h_move + band
+                }
+            })
+            .collect();
+        let mut next = core.clone();
+        for f in &self.faces {
+            if core[f.cl as usize] {
+                next[f.cr as usize] = true;
+            }
+            if core[f.cr as usize] {
+                next[f.cl as usize] = true;
+            }
+        }
+        for b in &self.boundaries {
+            next[b.cell as usize] = true;
+        }
+        self.active = next;
+    }
+
+    /// §15.4.4: the stable step over active cells.
+    fn stable_dt(&self) -> f64 {
+        let mut dt = self.max_dt;
+        for ci in 0..self.area.len() {
+            if !self.active[ci] || self.depth[ci] <= self.dry_depth {
+                continue;
+            }
+            let h = self.depth[ci];
+            let speed = (G * h).sqrt() + (self.qcx[ci].hypot(self.qcy[ci])) / h;
+            if self.metric[ci] > 0.0 && speed > 0.0 {
+                let l = (2.0 * self.area[ci] / self.metric[ci]).sqrt();
+                dt = dt.min(self.cfl * l / speed);
+            }
+        }
+        dt
+    }
+
+    /// §15.4.2 ∥ face phase (serial in this slice; per-face writes only).
+    fn fire_faces(&mut self, dt: f64) {
+        for fi in 0..self.faces.len() {
+            let f = &self.faces[fi];
+            let (cl, cr) = (f.cl as usize, f.cr as usize);
+            // Both-active gating: a one-sided face loses basin volume.
+            if !self.active[cl] || !self.active[cr] {
+                self.q[fi] = 0.0;
+                continue;
+            }
+            let h_f = match self.face_rec {
+                FaceReconstruction::Mean => face_depth_mean(self.eta[cl], self.eta[cr], f.z_face),
+                FaceReconstruction::VfrFace => {
+                    face_depth_vfr(self.eta[cl], self.eta[cr], f.z_lo, f.z_hi)
+                }
+            };
+            if h_f <= self.dry_depth {
+                self.q[fi] = 0.0;
+                continue;
+            }
+            let mut d_eta = self.eta[cr] - self.eta[cl];
+            if d_eta.abs() < ETA_DEADBAND {
+                d_eta = 0.0;
+            }
+            let slope = d_eta * f.inv_dn;
+            let q_perot =
+                0.5 * ((self.qcx[cl] + self.qcx[cr]) * f.nx + (self.qcy[cl] + self.qcy[cr]) * f.ny);
+            let q_hat = self.theta * self.q[fi] + (1.0 - self.theta) * q_perot;
+            let q_mag = self.q[fi]
+                .abs()
+                .max(0.5 * (self.qcx[cl] + self.qcx[cr]).hypot(self.qcy[cl] + self.qcy[cr]));
+            let h73 = h_f * h_f * h_f.cbrt();
+            let mut q_new = (q_hat - dt * G * h_f * slope) / (1.0 + G * dt * f.n2 * q_mag / h73);
+            // Froude cap.
+            let q_cap = self.froude_max * h_f * (G * h_f).sqrt();
+            q_new = q_new.clamp(-q_cap, q_cap);
+            // Positivity: the exporter grants at most β/3 of its volume
+            // per cell cycle.
+            let exporter = if q_new > 0.0 { cl } else { cr };
+            let budget = BETA / 3.0 * self.vol[exporter].max(0.0);
+            let take = q_new.abs() * f.psi * f.xi * dt;
+            if take > budget && take > 0.0 {
+                q_new *= budget / take;
+            }
+            self.q[fi] = q_new;
+            let dm = f.psi * q_new * f.xi * dt;
+            self.facc_l[fi] -= dm;
+            self.facc_r[fi] += dm;
+        }
+    }
+
+    /// §15.4.3 ∥ cell phase: gather own sides in fixed order, apply
+    /// sources, clamp, re-close.
+    fn fire_cells(&mut self, dt: f64) {
+        for ci in 0..self.area.len() {
+            let lo = self.cf_off[ci] as usize;
+            let hi = self.cf_off[ci + 1] as usize;
+            let mut flux = 0.0;
+            for &(fi, sign) in &self.cf_face[lo..hi] {
+                let fi = fi as usize;
+                if sign > 0.0 {
+                    flux += self.facc_l[fi];
+                    self.facc_l[fi] = 0.0;
+                } else {
+                    flux += self.facc_r[fi];
+                    self.facc_r[fi] = 0.0;
+                }
+            }
+            let a = self.area[ci];
+            let rain = self.rain[ci] * a * dt;
+            let coup = self.coupling[ci] * a * dt;
+            self.rain_in += rain;
+            // §15.4.3: evaporation shuts off C¹ as the cell dries, and
+            // takes no more than the cell holds.
+            let t = (self.depth[ci] / self.dry_depth).clamp(0.0, 1.0);
+            let ramp = t * t * (3.0 - 2.0 * t);
+            let want = self.evap[ci] * ramp * a * dt;
+            let before = self.vol[ci] + flux + rain + coup;
+            let take = want.min(before.max(0.0));
+            self.evap_out += take;
+            self.vol[ci] = (before - take).max(0.0);
+            self.reclose(ci);
+        }
+    }
+
+    /// §15.5: boundary laws, serially, in slot order, clamped in volume
+    /// space and booked as applied.
+    fn fire_boundaries(&mut self, dt: f64) {
+        for bi in 0..self.boundaries.len() {
+            let b = &self.boundaries[bi];
+            let ci = b.cell as usize;
+            let h = self.depth[ci];
+            // Inflow-positive volume the law asks to move this substep.
+            let asked: f64 = match b.law {
+                BoundaryLaw::NormalFlow { slope } => {
+                    if h <= self.dry_depth || slope <= 0.0 {
+                        0.0
+                    } else {
+                        -(h.powf(5.0 / 3.0) * slope.sqrt() / self.n_cell[ci]) * b.xi * dt
+                    }
+                }
+                BoundaryLaw::Flow { q_per_m } => -q_per_m * b.xi * dt,
+                BoundaryLaw::Stage { eta } => {
+                    // §15.5: the interior momentum law against a ghost
+                    // cell held at the stage.
+                    let h_f = match self.face_rec {
+                        FaceReconstruction::Mean => eta.max(self.eta[ci]) - self.z_mean[ci],
+                        FaceReconstruction::VfrFace => {
+                            face_depth_vfr(eta, self.eta[ci], self.bed[ci].z1, self.bed[ci].z3)
+                        }
+                    };
+                    if h_f <= self.dry_depth {
+                        self.boundaries[bi].q = 0.0;
+                        continue;
+                    }
+                    let mut d_eta = self.eta[ci] - eta;
+                    if d_eta.abs() < ETA_DEADBAND {
+                        d_eta = 0.0;
+                    }
+                    let slope = d_eta * b.inv_dn_ghost;
+                    let n2 = self.n_cell[ci] * self.n_cell[ci];
+                    let h73 = h_f * h_f * h_f.cbrt();
+                    let q_prev = self.boundaries[bi].q;
+                    let mut q_new =
+                        (q_prev - dt * G * h_f * slope) / (1.0 + G * dt * n2 * q_prev.abs() / h73);
+                    let q_cap = self.froude_max * h_f * (G * h_f).sqrt();
+                    q_new = q_new.clamp(-q_cap, q_cap);
+                    self.boundaries[bi].q = q_new;
+                    let b = &self.boundaries[bi];
+                    q_new * b.xi * dt
+                }
+            };
+            let b = &self.boundaries[bi];
+            // Volume clamps (§15.5): a cell cannot be driven negative,
+            // and one substep of a stage boundary moves the cell at most
+            // TO the stage, from either side.
+            let v_old = self.vol[ci];
+            let mut v_new = v_old + asked;
+            if let BoundaryLaw::Stage { eta } = b.law {
+                let h_eq = match self.closure {
+                    CellClosure::Flat => (eta - self.z_mean[ci]).max(0.0),
+                    CellClosure::Vfr => super::closure::vfr_mean_depth(&self.bed[ci], eta),
+                };
+                let v_eq = h_eq * self.area[ci];
+                v_new = if asked < 0.0 {
+                    v_new.max(v_old.min(v_eq))
+                } else {
+                    v_new.min(v_old.max(v_eq))
+                };
+            }
+            v_new = v_new.max(0.0);
+            let applied = v_new - v_old;
+            // §15.5: momentum matches applied mass — a clamped exchange
+            // that kept its unclamped momentum would wind up and drive
+            // the basin as an oscillator.
+            self.boundaries[bi].q = if b.xi > 1e-12 && dt > 0.0 {
+                applied / (b.xi * dt)
+            } else {
+                0.0
+            };
+            // Booking follows application exactly (§15.5).
+            if applied >= 0.0 {
+                self.boundary_in += applied;
+            } else {
+                self.boundary_out -= applied;
+            }
+            self.vol[ci] = v_new;
+            self.reclose(ci);
+        }
+    }
+
+    /// Advance to exactly `span` seconds from now (§15.4.4: an advance
+    /// always reaches its target).
+    pub fn advance(&mut self, span: f64) {
+        let mut remaining = span;
+        // Rebuild cadence: every fourth macro cycle of the (future) tier
+        // ladder — with the single-tier march, every 4·2^(K−1) substeps.
+        let rebuild_every = 4u64 << (self.lts_tiers.saturating_sub(1));
+        let mut dt0 = self.stable_dt();
+        while remaining > 1e-12 {
+            if self.substep.is_multiple_of(rebuild_every) {
+                self.rebuild_active();
+                dt0 = self.stable_dt();
+            } else {
+                // Between rebuilds the step may only tighten.
+                dt0 = dt0.min(self.stable_dt());
+            }
+            let dt = dt0.min(remaining);
+            self.fire_faces(dt);
+            self.fire_cells(dt);
+            self.fire_boundaries(dt);
+            self.refresh_perot();
+            self.substep += 1;
+            remaining -= dt;
+        }
+    }
+
+    /// Total stored volume (m³), the conservation ledger's storage term.
+    pub fn storage(&self) -> f64 {
+        self.vol.iter().sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overland::{MeshCell, MeshVertex, OverlandMesh};
+
+    /// A 1 m wide strip of `nx` quads split into triangles, bed `z(x)`.
+    fn strip(nx: usize, dx: f64, z: impl Fn(f64) -> f64) -> OverlandMesh {
+        let mut mesh = OverlandMesh::default();
+        for i in 0..=nx {
+            let x = dx * i as f64;
+            for y in [0.0, 1.0] {
+                mesh.verts.push(MeshVertex {
+                    x,
+                    y,
+                    z: z(x),
+                    tag: None,
+                });
+            }
+        }
+        for i in 0..nx {
+            let (a, b) = ((2 * i) as u32, (2 * i + 1) as u32);
+            let (c, d) = ((2 * i + 2) as u32, (2 * i + 3) as u32);
+            // Alternate the quad split so the diagonals herringbone:
+            // one orientation biases the strip's effective conveyance.
+            let (t1, t2) = if i % 2 == 0 {
+                ([a, b, c], [b, d, c])
+            } else {
+                ([a, b, d], [a, d, c])
+            };
+            mesh.cells.push(MeshCell {
+                v: t1,
+                n: 0.03,
+                h0: 0.0,
+                tag: None,
+            });
+            mesh.cells.push(MeshCell {
+                v: t2,
+                n: 0.03,
+                h0: 0.0,
+                tag: None,
+            });
+        }
+        mesh
+    }
+
+    fn fill_to_stage(mesh: &mut OverlandMesh, eta0: f64) {
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .map(|mut c| {
+                let zm = c.v.iter().map(|&v| mesh.verts[v as usize].z).sum::<f64>() / 3.0;
+                c.h0 = (eta0 - zm).max(0.0);
+                c
+            })
+            .collect();
+    }
+
+    fn build(mesh: &OverlandMesh) -> Marcher {
+        let topo = Topology::build(mesh).expect("valid mesh");
+        Marcher::build(mesh, &topo)
+    }
+
+    /// §15.9: a lake at rest over an immersed bump stays exactly at
+    /// rest, under both closures — the well-balancing property.
+    #[test]
+    fn a_lake_at_rest_stays_at_rest() {
+        for closure in [CellClosure::Flat, CellClosure::Vfr] {
+            let mut mesh = strip(20, 1.0, |x| {
+                10.0 + 0.3 * (-((x - 10.0) / 3.0) * ((x - 10.0) / 3.0)).exp()
+            });
+            mesh.options.cell_closure = closure;
+            fill_to_stage(&mut mesh, 10.6);
+            let mut m = build(&mesh);
+            let v0 = m.storage();
+            m.advance(60.0);
+            assert!(
+                m.q.iter().all(|q| q.abs() < 1e-10),
+                "{closure:?}: max q {}",
+                m.q.iter().fold(0.0_f64, |a, q| a.max(q.abs()))
+            );
+            assert!(((m.storage() - v0) / v0).abs() < 1e-12, "{closure:?}");
+        }
+    }
+
+    /// §15.9: an emerged bump keeps its dry crest dry — no uphill creep
+    /// — while the wet flanks stay still.
+    #[test]
+    fn an_emerged_bump_stays_dry_and_still() {
+        let mut mesh = strip(20, 1.0, |x| {
+            10.0 + 0.5 * (-((x - 10.0) / 2.5) * ((x - 10.0) / 2.5)).exp()
+        });
+        fill_to_stage(&mut mesh, 10.2);
+        let mut m = build(&mesh);
+        let dry0: Vec<bool> = m.depth.iter().map(|&d| d == 0.0).collect();
+        assert!(dry0.iter().any(|&d| d), "the crest starts dry");
+        m.advance(60.0);
+        for (ci, was_dry) in dry0.iter().enumerate() {
+            if *was_dry {
+                assert_eq!(m.vol[ci], 0.0, "cell {ci} crept uphill");
+            }
+        }
+        assert!(m.q.iter().all(|q| q.abs() < 1e-10));
+    }
+
+    /// §15.9: a closed basin conserves — storage change equals the
+    /// ledger exactly, rain and evaporation included.
+    #[test]
+    fn a_closed_basin_conserves_to_its_ledger() {
+        let mut mesh = strip(12, 1.0, |x| 10.0 - 0.02 * x);
+        fill_to_stage(&mut mesh, 10.05);
+        let mut m = build(&mesh);
+        let v0 = m.storage();
+        for r in &mut m.rain {
+            *r = 5.0e-6;
+        }
+        for e in &mut m.evap {
+            *e = 1.0e-6;
+        }
+        m.advance(600.0);
+        let expected = v0 + m.rain_in - m.evap_out + m.boundary_in - m.boundary_out;
+        let scale = m.storage().max(1.0);
+        assert!(
+            ((m.storage() - expected) / scale).abs() < 1e-10,
+            "storage {} vs ledger {expected}",
+            m.storage()
+        );
+    }
+
+    /// A rectangular grid of split quads, the reference configuration
+    /// the steady-slope gates run on: `nx` by `ny` quads of side `dx`.
+    fn grid(nx: usize, ny: usize, dx: f64, z: impl Fn(f64, f64) -> f64) -> OverlandMesh {
+        let mut mesh = OverlandMesh::default();
+        let nvx = nx + 1;
+        for j in 0..=ny {
+            for i in 0..=nx {
+                let (x, y) = (dx * i as f64, dx * j as f64);
+                mesh.verts.push(MeshVertex {
+                    x,
+                    y,
+                    z: z(x, y),
+                    tag: None,
+                });
+            }
+        }
+        for j in 0..ny {
+            for i in 0..nx {
+                let v00 = (j * nvx + i) as u32;
+                let v10 = (j * nvx + i + 1) as u32;
+                let v01 = ((j + 1) * nvx + i) as u32;
+                let v11 = ((j + 1) * nvx + i + 1) as u32;
+                mesh.cells.push(MeshCell {
+                    v: [v00, v10, v11],
+                    n: 0.03,
+                    h0: 0.0,
+                    tag: None,
+                });
+                mesh.cells.push(MeshCell {
+                    v: [v00, v11, v01],
+                    n: 0.03,
+                    h0: 0.0,
+                    tag: None,
+                });
+            }
+        }
+        mesh
+    }
+
+    /// §15.9: steady rain on a sloped plane with a Manning outfall along
+    /// the downhill boundary reaches the normal-depth equilibrium:
+    /// outflow within 10% of the rain rate, mid-strip mean depth within
+    /// 6% of Manning normal depth — the reference configuration and
+    /// envelope (about 2.5% first-order staggering plus about 1% from
+    /// the vector-magnitude friction at this resolution).
+    #[test]
+    fn steady_rain_on_a_slope_finds_normal_depth() {
+        let (nx, ny, dx, s) = (40usize, 4usize, 1.0, 0.01);
+        let rain = 2.0e-4; // 720 mm/h: normal depth ~18 mm, above the bands
+        let mut mesh = grid(nx, ny, dx, |x, _| 10.0 + s * x);
+        let topo = Topology::build(&mesh).expect("valid");
+        // NORMAL_FLOW along the whole downhill (x = 0) boundary.
+        let mut outlets = 0;
+        for ci in 0..mesh.cells.len() {
+            for e in 0..3usize {
+                let slot = ci * 3 + e;
+                if topo.neighbour[slot].is_none() && topo.edge_mid[slot][0] < 1e-9 {
+                    mesh.boundaries.push(crate::overland::BoundaryRow {
+                        cell: ci as u32,
+                        edge: e as u8,
+                        condition: BoundaryCondition::NormalFlow { slope: s },
+                        group: None,
+                    });
+                    outlets += 1;
+                }
+            }
+        }
+        assert!(outlets > 0);
+        let mut m = build(&mesh);
+        for r in &mut m.rain {
+            *r = rain;
+        }
+        m.advance(6000.0);
+        let v_start = m.storage();
+        let b_out_0 = m.boundary_out;
+        let window = 1000.0;
+        m.advance(window);
+        // Exact ledger identity over the window.
+        let rain_window = rain * m.area.iter().sum::<f64>() * window;
+        let out_window = m.boundary_out - b_out_0;
+        let ds = m.storage() - v_start;
+        assert!(
+            (rain_window - out_window - ds).abs() < 1e-8 * rain_window,
+            "ledger: rain {rain_window} out {out_window} ds {ds}"
+        );
+        // Rate: outflow tracks the rain input.
+        assert!(
+            (out_window / rain_window - 1.0).abs() < 0.10,
+            "outflow {out_window} vs rain {rain_window}"
+        );
+        // Mid-strip mean depth against the local normal depth.
+        let l = nx as f64 * dx;
+        let x_mid = 0.5 * l;
+        let q_mid = rain * (l - x_mid);
+        let h_n = (0.03 * q_mid / s.sqrt()).powf(3.0 / 5.0);
+        let topo2 = Topology::build(&mesh).expect("valid");
+        let (mut h_sum, mut h_cnt) = (0.0, 0u32);
+        for ci in 0..m.depth.len() {
+            if (topo2.centroid[ci][0] - x_mid).abs() < dx {
+                h_sum += m.depth[ci];
+                h_cnt += 1;
+            }
+        }
+        let h_avg = h_sum / f64::from(h_cnt);
+        assert!(
+            (h_avg / h_n - 1.0).abs() < 0.06,
+            "mid-strip depth {h_avg} vs normal {h_n}"
+        );
+    }
+
+    /// §15.5: a stage boundary fills a dry basin toward its stage and
+    /// never overshoots the equilibrium; the ledger matches the water.
+    #[test]
+    fn a_stage_boundary_fills_to_equilibrium() {
+        let mut mesh = strip(10, 1.0, |_| 10.0);
+        mesh.boundaries.push(crate::overland::BoundaryRow {
+            cell: 0,
+            edge: 2,
+            condition: BoundaryCondition::Stage(SeriesOrValue::Value(10.3)),
+            group: None,
+        });
+        let mut m = build(&mesh);
+        // The filling front carries momentum, so cells overshoot the
+        // stage transiently; the settled state is the claim. The fed
+        // cell's equilibrium clamp bounds what the boundary admits.
+        for _ in 0..100 {
+            m.advance(30.0);
+        }
+        for (ci, &eta) in m.eta.iter().enumerate() {
+            assert!(
+                (eta - 10.3).abs() < 5e-3,
+                "cell {ci} settled off-stage: {eta}"
+            );
+        }
+        let expected = m.boundary_in - m.boundary_out;
+        assert!(
+            ((m.storage() - expected) / m.storage()).abs() < 1e-10,
+            "ledger closes"
+        );
+    }
+}

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -24,6 +24,12 @@ const ETA_DEADBAND: f64 = 1e-12;
 /// §15.4.2: the exporting cell's per-face volume share β.
 const BETA: f64 = 0.8;
 
+/// §15.4.5: elements per worker below which a phase runs serial — a
+/// dispatch costs more than a small map saves, and byte-identity makes
+/// the two paths interchangeable.
+#[cfg(feature = "threads")]
+const PAR_GRAIN: usize = 256;
+
 /// One interior face: a single prognostic discharge shared by two cells,
 /// oriented from the lower-indexed cell to the higher.
 #[derive(Debug, Clone)]
@@ -154,6 +160,13 @@ pub struct Marcher {
     peak_active: usize,
     /// Initial storage (m³), the §15.8 ledger's opening term.
     storage0: f64,
+    /// Per-cell ledger scratch for the ∥ cell phase: (rain, coupling,
+    /// evaporation take), reduced serially in index order so the sums
+    /// are byte-identical at every width (§15.4.5).
+    led: Vec<[f64; 3]>,
+    /// §15.4.5: the worker team, when the model asked for width.
+    #[cfg(feature = "threads")]
+    team: Option<crate::hydraulics::team::Team>,
 
     // ── Sources, set by the caller before an advance (m/s) ─────────
     pub rain: Vec<f64>,
@@ -238,6 +251,24 @@ pub struct CouplingPoint {
     /// Unauthored areas are eligible for `COUPLING_AREA AUTO` (§15.6).
     pub area_authored: bool,
 }
+
+/// The §15.4.3 cell phase's taken-out state, as raw pointers.
+struct CellPtrs {
+    vol: *mut f64,
+    depth: *mut f64,
+    eta: *mut f64,
+    qcx: *mut f64,
+    qcy: *mut f64,
+    fl: *mut f64,
+    fr: *mut f64,
+    led: *mut [f64; 3],
+}
+
+// SAFETY: the cell phase's writes are per-cell disjoint (see
+// [`Marcher::fire_cell_at`]), which is what makes sharing the pointers
+// across the team sound.
+#[cfg(feature = "threads")]
+unsafe impl Sync for CellPtrs {}
 
 impl Marcher {
     /// Build from a validated mesh and its topology. Initial volumes come
@@ -499,6 +530,9 @@ impl Marcher {
             advanced: 0.0,
             peak_active: 0,
             storage0: 0.0,
+            led: vec![[0.0; 3]; nc],
+            #[cfg(feature = "threads")]
+            team: None,
             rain: vec![0.0; nc],
             evap: vec![0.0; nc],
             coupling: vec![0.0; nc],
@@ -534,14 +568,21 @@ impl Marcher {
         m
     }
 
-    /// Re-derive a cell's surface from its volume (§15.3).
-    fn reclose(&mut self, ci: usize) {
-        let h = self.vol[ci].max(0.0) / self.area[ci];
-        self.depth[ci] = h;
-        self.eta[ci] = match self.closure {
+    /// A cell's (depth, surface) closure for a volume (§15.3), pure.
+    fn close_of(&self, ci: usize, vol: f64) -> (f64, f64) {
+        let h = vol.max(0.0) / self.area[ci];
+        let eta = match self.closure {
             CellClosure::Flat => flat_eta(&self.bed[ci], h),
             CellClosure::Vfr => vfr_eta(&self.bed[ci], h, self.vfr_eps),
         };
+        (h, eta)
+    }
+
+    /// Re-derive a cell's surface from its volume (§15.3).
+    fn reclose(&mut self, ci: usize) {
+        let (h, eta) = self.close_of(ci, self.vol[ci]);
+        self.depth[ci] = h;
+        self.eta[ci] = eta;
     }
 
     /// §15.4.3 Perot reconstruction over each cell's faces, fixed order:
@@ -558,6 +599,13 @@ impl Marcher {
 
     /// One cell's interior-face reconstruction, at its firing.
     fn perot_cell(&mut self, ci: usize) {
+        let (x, y) = self.perot_of(ci);
+        self.qcx[ci] = x;
+        self.qcy[ci] = y;
+    }
+
+    /// The reconstruction itself, pure over the face discharges.
+    fn perot_of(&self, ci: usize) -> (f64, f64) {
         let (mut sx, mut sy) = (0.0, 0.0);
         let lo = self.cf_off[ci] as usize;
         let hi = self.cf_off[ci + 1] as usize;
@@ -567,8 +615,7 @@ impl Marcher {
             sx += flux * (f.mx - self.cx[ci]);
             sy += flux * (f.my - self.cy[ci]);
         }
-        self.qcx[ci] = sx / self.area[ci];
-        self.qcy[ci] = sy / self.area[ci];
+        (sx / self.area[ci], sy / self.area[ci])
     }
 
     /// §15.5 completion: a boundary edge's discharge belongs to its
@@ -712,6 +759,13 @@ impl Marcher {
             self.exchange[k] += dv;
             self.reclose(ci);
         }
+    }
+
+    /// §15.4.5: give the march the §6.4 worker width. Widths below 2
+    /// stay serial; results are byte-identical either way.
+    #[cfg(feature = "threads")]
+    pub fn set_width(&mut self, width: usize) {
+        self.team = crate::hydraulics::team::Team::new(width);
     }
 
     /// The §15.4.4 drying depth (m), for callers keying wetness ramps.
@@ -936,112 +990,243 @@ impl Marcher {
         }
     }
 
-    /// §15.4.2 ∥ face phase (serial in this slice; per-face writes
-    /// only): fire every face whose tier is due at base substep `s`,
-    /// each over its own tier's interval.
-    fn fire_faces(&mut self, dt0: f64, s: u64) {
-        for fi in 0..self.faces.len() {
-            if !s.is_multiple_of(1u64 << self.face_tier[fi]) {
-                continue;
-            }
-            let dt = dt0 * f64::from(1u32 << self.face_tier[fi]);
-            let f = &self.faces[fi];
-            let (cl, cr) = (f.cl as usize, f.cr as usize);
-            // Both-active gating: a one-sided face loses basin volume.
-            if !self.active[cl] || !self.active[cr] {
-                self.q[fi] = 0.0;
-                continue;
-            }
-            let h_f = match self.face_rec {
-                FaceReconstruction::Mean => face_depth_mean(self.eta[cl], self.eta[cr], f.z_face),
-                FaceReconstruction::VfrFace => {
-                    face_depth_vfr(self.eta[cl], self.eta[cr], f.z_lo, f.z_hi)
-                }
-            };
-            if h_f <= self.dry_depth {
-                self.q[fi] = 0.0;
-                continue;
-            }
-            let mut d_eta = self.eta[cr] - self.eta[cl];
-            if d_eta.abs() < ETA_DEADBAND {
-                d_eta = 0.0;
-            }
-            let slope = d_eta * f.inv_dn;
-            let q_perot =
-                0.5 * ((self.qcx[cl] + self.qcx[cr]) * f.nx + (self.qcy[cl] + self.qcy[cr]) * f.ny);
-            let q_hat = self.theta * self.q[fi] + (1.0 - self.theta) * q_perot;
-            let q_mag = self.q[fi]
-                .abs()
-                .max(0.5 * (self.qcx[cl] + self.qcx[cr]).hypot(self.qcy[cl] + self.qcy[cr]));
-            let h73 = h_f * h_f * h_f.cbrt();
-            let mut q_new = (q_hat - dt * G * h_f * slope) / (1.0 + G * dt * f.n2 * q_mag / h73);
-            // Froude cap.
-            let q_cap = self.froude_max * h_f * (G * h_f).sqrt();
-            q_new = q_new.clamp(-q_cap, q_cap);
-            // Positivity: the exporter grants at most β/3 of its volume
-            // per cell cycle, divided by the times this face fires
-            // within the exporter's cycle (§15.4.4) — repeated takes at
-            // a tier interface would otherwise drain the cell into the
-            // backstop.
-            let exporter = if q_new > 0.0 { cl } else { cr };
-            let refire = 1u32 << (self.tier[exporter] - self.face_tier[fi]);
-            let budget = BETA / 3.0 / f64::from(refire) * self.vol[exporter].max(0.0);
-            let take = q_new.abs() * f.psi * f.xi * dt;
-            if take > budget && take > 0.0 {
-                q_new *= budget / take;
-            }
-            self.q[fi] = q_new;
-            let dm = f.psi * q_new * f.xi * dt;
-            self.facc_l[fi] -= dm;
-            self.facc_r[fi] += dm;
+    /// One face's §15.4.2 firing. The face arrays are taken out of
+    /// `self` for the phase and passed as raw pointers.
+    ///
+    /// # Safety
+    /// Reads and writes only index `fi` of `q`, `fl` and `fr`; callers
+    /// run disjoint `fi` concurrently and nothing else touches those
+    /// arrays during the phase.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn fire_face_at(
+        &self,
+        fi: usize,
+        dt0: f64,
+        s: u64,
+        q: *mut f64,
+        fl: *mut f64,
+        fr: *mut f64,
+    ) {
+        if !s.is_multiple_of(1u64 << self.face_tier[fi]) {
+            return;
         }
+        let dt = dt0 * f64::from(1u32 << self.face_tier[fi]);
+        let f = &self.faces[fi];
+        let (cl, cr) = (f.cl as usize, f.cr as usize);
+        // Both-active gating: a one-sided face loses basin volume.
+        if !self.active[cl] || !self.active[cr] {
+            *q.add(fi) = 0.0;
+            return;
+        }
+        let h_f = match self.face_rec {
+            FaceReconstruction::Mean => face_depth_mean(self.eta[cl], self.eta[cr], f.z_face),
+            FaceReconstruction::VfrFace => {
+                face_depth_vfr(self.eta[cl], self.eta[cr], f.z_lo, f.z_hi)
+            }
+        };
+        if h_f <= self.dry_depth {
+            *q.add(fi) = 0.0;
+            return;
+        }
+        let q_old = *q.add(fi);
+        let mut d_eta = self.eta[cr] - self.eta[cl];
+        if d_eta.abs() < ETA_DEADBAND {
+            d_eta = 0.0;
+        }
+        let slope = d_eta * f.inv_dn;
+        let q_perot =
+            0.5 * ((self.qcx[cl] + self.qcx[cr]) * f.nx + (self.qcy[cl] + self.qcy[cr]) * f.ny);
+        let q_hat = self.theta * q_old + (1.0 - self.theta) * q_perot;
+        let q_mag = q_old
+            .abs()
+            .max(0.5 * (self.qcx[cl] + self.qcx[cr]).hypot(self.qcy[cl] + self.qcy[cr]));
+        let h73 = h_f * h_f * h_f.cbrt();
+        let mut q_new = (q_hat - dt * G * h_f * slope) / (1.0 + G * dt * f.n2 * q_mag / h73);
+        // Froude cap.
+        let q_cap = self.froude_max * h_f * (G * h_f).sqrt();
+        q_new = q_new.clamp(-q_cap, q_cap);
+        // Positivity: the exporter grants at most β/3 of its volume
+        // per cell cycle, divided by the times this face fires
+        // within the exporter's cycle (§15.4.4) — repeated takes at
+        // a tier interface would otherwise drain the cell into the
+        // backstop.
+        let exporter = if q_new > 0.0 { cl } else { cr };
+        let refire = 1u32 << (self.tier[exporter] - self.face_tier[fi]);
+        let budget = BETA / 3.0 / f64::from(refire) * self.vol[exporter].max(0.0);
+        let take = q_new.abs() * f.psi * f.xi * dt;
+        if take > budget && take > 0.0 {
+            q_new *= budget / take;
+        }
+        *q.add(fi) = q_new;
+        let dm = f.psi * q_new * f.xi * dt;
+        *fl.add(fi) -= dm;
+        *fr.add(fi) += dm;
+    }
+
+    /// §15.4.2 ∥ face phase: fire every face whose tier is due at base
+    /// substep `s`, each over its own tier's interval — across the
+    /// worker team when the model asked for width, byte-identical at
+    /// any (§15.4.5).
+    fn fire_faces(&mut self, dt0: f64, s: u64) {
+        let mut q = std::mem::take(&mut self.q);
+        let mut fl = std::mem::take(&mut self.facc_l);
+        let mut fr = std::mem::take(&mut self.facc_r);
+        let (qp, flp, frp) = (q.as_mut_ptr(), fl.as_mut_ptr(), fr.as_mut_ptr());
+        #[cfg(feature = "threads")]
+        {
+            if let Some(mut team) = self.team.take() {
+                if self.faces.len() >= PAR_GRAIN * team.width() {
+                    use crate::hydraulics::team::SendPtr;
+                    let (qs, fls, frs) = (SendPtr::new(qp), SendPtr::new(flp), SendPtr::new(frp));
+                    let me = &*self;
+                    // SAFETY: per-face disjoint reads/writes, as the
+                    // body's contract states.
+                    team.run(me.faces.len(), |fi| unsafe {
+                        me.fire_face_at(fi, dt0, s, qs.get(), fls.get(), frs.get());
+                    });
+                    self.team = Some(team);
+                    self.q = q;
+                    self.facc_l = fl;
+                    self.facc_r = fr;
+                    return;
+                }
+                self.team = Some(team);
+            }
+        }
+        for fi in 0..self.faces.len() {
+            // SAFETY: serial — the pointers are exclusive here.
+            unsafe { self.fire_face_at(fi, dt0, s, qp, flp, frp) };
+        }
+        self.q = q;
+        self.facc_l = fl;
+        self.facc_r = fr;
+    }
+
+    /// One cell's §15.4.3 firing. The cell-state arrays and the face
+    /// accumulators are taken out of `self` for the phase and passed as
+    /// raw pointers; ledger contributions land in the per-cell scratch
+    /// for the driver's serial reduction.
+    ///
+    /// # Safety
+    /// Reads and writes only this cell's indices — its own slots of
+    /// `vol`/`depth`/`eta`/`qcx`/`qcy`/`led`, and its **own sides** of
+    /// its incident faces' accumulators, which no other cell owns.
+    /// Callers run disjoint `ci` concurrently and nothing else touches
+    /// these arrays during the phase.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn fire_cell_at(&self, ci: usize, dt0: f64, s: u64, p: &CellPtrs) {
+        if !s.is_multiple_of(1u64 << self.tier[ci]) {
+            return;
+        }
+        let dt = dt0 * f64::from(1u32 << self.tier[ci]);
+        let lo = self.cf_off[ci] as usize;
+        let hi = self.cf_off[ci + 1] as usize;
+        let mut flux = 0.0;
+        for &(fi, sign) in &self.cf_face[lo..hi] {
+            let fi = fi as usize;
+            if sign > 0.0 {
+                flux += *p.fl.add(fi);
+                *p.fl.add(fi) = 0.0;
+            } else {
+                flux += *p.fr.add(fi);
+                *p.fr.add(fi) = 0.0;
+            }
+        }
+        let a = self.area[ci];
+        let rain = self.rain[ci] * a * dt;
+        let coup = self.coupling[ci] * a * dt;
+        // §15.4.3: evaporation shuts off C¹ as the cell dries, and
+        // takes no more than the cell holds.
+        let t = (*p.depth.add(ci) / self.dry_depth).clamp(0.0, 1.0);
+        let ramp = t * t * (3.0 - 2.0 * t);
+        let want = self.evap[ci] * ramp * a * dt;
+        let before = *p.vol.add(ci) + flux + rain + coup;
+        let take = want.min(before.max(0.0));
+        let v_new = (before - take).max(0.0);
+        *p.vol.add(ci) = v_new;
+        let (h, eta) = self.close_of(ci, v_new);
+        *p.depth.add(ci) = h;
+        *p.eta.add(ci) = eta;
+        let (qx, qy) = self.perot_of(ci);
+        *p.qcx.add(ci) = qx;
+        *p.qcy.add(ci) = qy;
+        *p.led.add(ci) = [rain, coup, take];
     }
 
     /// §15.4.3 ∥ cell phase: every cell whose tier is due at base
     /// substep `s` gathers its own accumulator sides in fixed order,
     /// applies its sources over its own tier's interval, clamps,
-    /// re-closes, and refreshes its velocity reconstruction.
+    /// re-closes, and refreshes its velocity reconstruction — across
+    /// the worker team when the model asked for width. The §15.8
+    /// ledger reduces serially in index order afterwards, so its sums
+    /// are byte-identical at every width (§15.4.5).
     fn fire_cells(&mut self, dt0: f64, s: u64) {
-        for ci in 0..self.area.len() {
+        let nc = self.area.len();
+        let mut vol = std::mem::take(&mut self.vol);
+        let mut depth = std::mem::take(&mut self.depth);
+        let mut eta = std::mem::take(&mut self.eta);
+        let mut qcx = std::mem::take(&mut self.qcx);
+        let mut qcy = std::mem::take(&mut self.qcy);
+        let mut fl = std::mem::take(&mut self.facc_l);
+        let mut fr = std::mem::take(&mut self.facc_r);
+        let mut led = std::mem::take(&mut self.led);
+        let ptrs = CellPtrs {
+            vol: vol.as_mut_ptr(),
+            depth: depth.as_mut_ptr(),
+            eta: eta.as_mut_ptr(),
+            qcx: qcx.as_mut_ptr(),
+            qcy: qcy.as_mut_ptr(),
+            fl: fl.as_mut_ptr(),
+            fr: fr.as_mut_ptr(),
+            led: led.as_mut_ptr(),
+        };
+        let mut ran = false;
+        #[cfg(feature = "threads")]
+        {
+            if let Some(mut team) = self.team.take() {
+                if nc >= PAR_GRAIN * team.width() {
+                    let shared = &ptrs;
+                    let me = &*self;
+                    // SAFETY: per-cell disjoint reads/writes — a cell
+                    // touches only its own slots and its own sides of
+                    // its incident faces' accumulators.
+                    team.run(nc, |ci| unsafe {
+                        me.fire_cell_at(ci, dt0, s, shared);
+                    });
+                    ran = true;
+                }
+                self.team = Some(team);
+            }
+        }
+        if !ran {
+            for ci in 0..nc {
+                // SAFETY: serial — the pointers are exclusive here.
+                unsafe { self.fire_cell_at(ci, dt0, s, &ptrs) };
+            }
+        }
+        self.vol = vol;
+        self.depth = depth;
+        self.eta = eta;
+        self.qcx = qcx;
+        self.qcy = qcy;
+        self.facc_l = fl;
+        self.facc_r = fr;
+        self.led = led;
+        // §15.8: the ledger reduction, serial and in index order.
+        for ci in 0..nc {
             if !s.is_multiple_of(1u64 << self.tier[ci]) {
                 continue;
             }
-            let dt = dt0 * f64::from(1u32 << self.tier[ci]);
-            let lo = self.cf_off[ci] as usize;
-            let hi = self.cf_off[ci + 1] as usize;
-            let mut flux = 0.0;
-            for &(fi, sign) in &self.cf_face[lo..hi] {
-                let fi = fi as usize;
-                if sign > 0.0 {
-                    flux += self.facc_l[fi];
-                    self.facc_l[fi] = 0.0;
-                } else {
-                    flux += self.facc_r[fi];
-                    self.facc_r[fi] = 0.0;
-                }
-            }
-            let a = self.area[ci];
-            let rain = self.rain[ci] * a * dt;
-            let coup = self.coupling[ci] * a * dt;
+            let [rain, coup, take] = self.led[ci];
             self.rain_in += rain;
-            // §15.8: the injection path books separately from the
-            // junction orifice exchange.
+            // The injection path books separately from the junction
+            // orifice exchange.
             if coup >= 0.0 {
                 self.outfall_in += coup;
             } else {
                 self.outfall_out += -coup;
             }
-            // §15.4.3: evaporation shuts off C¹ as the cell dries, and
-            // takes no more than the cell holds.
-            let t = (self.depth[ci] / self.dry_depth).clamp(0.0, 1.0);
-            let ramp = t * t * (3.0 - 2.0 * t);
-            let want = self.evap[ci] * ramp * a * dt;
-            let before = self.vol[ci] + flux + rain + coup;
-            let take = want.min(before.max(0.0));
             self.evap_out += take;
-            self.vol[ci] = (before - take).max(0.0);
-            self.reclose(ci);
-            self.perot_cell(ci);
         }
     }
 
@@ -1900,6 +2085,113 @@ mod tests {
         );
     }
 
+    /// §15.9 SWASHES 3.2.1: the MacDonald 1000 m subcritical profile.
+    /// The bed is derived from the full steady momentum equation for a
+    /// prescribed depth profile, so the analytic solution is exact by
+    /// construction; the scheme omits convective acceleration, and its
+    /// steady surface differs by the integrated velocity-head term. The
+    /// grade bounds the relative L1 depth error of the settled
+    /// time-mean field at 2.5% (the predecessor's own marcher measures
+    /// 2.0% on this case).
+    #[test]
+    fn macdonald_subcritical_profile() {
+        let (l, q_in, n_man) = (1000.0, 2.0, 0.033);
+        let a_h = (4.0 / G).powf(1.0 / 3.0);
+        let h_ex = |x: f64| a_h * (1.0 + 0.5 * (-16.0 * (x / l - 0.5).powi(2)).exp());
+        let dh_ex = |x: f64| {
+            a_h * 0.5 * (-16.0 * (x / l - 0.5).powi(2)).exp() * (-32.0 * (x / l - 0.5) / l)
+        };
+        // Bed from the full steady momentum equation, z(L) = 0:
+        // z(x) = ∫ₓᴸ [(1 − Fr²) h′ + n² q² / h^{10/3}] ds.
+        let integrand = |x: f64| {
+            let h = h_ex(x);
+            let fr2 = q_in * q_in / (G * h * h * h);
+            (1.0 - fr2) * dh_ex(x) + n_man * n_man * q_in * q_in / h.powf(10.0 / 3.0)
+        };
+        // Cumulative trapezoid on a fine grid, then linear lookup.
+        let m = 4000usize;
+        let ds = l / m as f64;
+        let mut z_tab = vec![0.0; m + 1];
+        for i in (0..m).rev() {
+            let x0 = ds * i as f64;
+            z_tab[i] = z_tab[i + 1] + 0.5 * ds * (integrand(x0) + integrand(x0 + ds));
+        }
+        let z_of = |x: f64| {
+            let f = (x / ds).clamp(0.0, m as f64);
+            let i = (f as usize).min(m - 1);
+            let t = f - i as f64;
+            z_tab[i] * (1.0 - t) + z_tab[i + 1] * t
+        };
+
+        let (nx, ny, dx) = (200usize, 2usize, 5.0);
+        let mut mesh = grid(nx, ny, dx, |x, _| z_of(x));
+        let topo = Topology::build(&mesh).expect("valid");
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .enumerate()
+            .map(|(ci, mut c)| {
+                c.n = n_man;
+                c.h0 = h_ex(topo.centroid[ci][0]);
+                c
+            })
+            .collect();
+        for ci in 0..mesh.cells.len() {
+            for e in 0..3usize {
+                let slot = ci * 3 + e;
+                if topo.neighbour[slot].is_some() {
+                    continue;
+                }
+                let x = topo.edge_mid[slot][0];
+                if x < 1e-9 {
+                    mesh.boundaries.push(crate::overland::BoundaryRow {
+                        cell: ci as u32,
+                        edge: e as u8,
+                        condition: BoundaryCondition::Flow(SeriesOrValue::Value(-q_in)),
+                        group: None,
+                    });
+                } else if x > l - 1e-9 {
+                    mesh.boundaries.push(crate::overland::BoundaryRow {
+                        cell: ci as u32,
+                        edge: e as u8,
+                        condition: BoundaryCondition::Stage(SeriesOrValue::Value(h_ex(l))),
+                        group: None,
+                    });
+                }
+            }
+        }
+        let mut m = build(&mesh);
+        // Settle, then grade the time mean of the final half.
+        m.advance(2000.0);
+        let mut mean = vec![0.0; m.depth.len()];
+        let samples = 400u32;
+        for _ in 0..samples {
+            m.advance(5.0);
+            for (a, h) in mean.iter_mut().zip(&m.depth) {
+                *a += h;
+            }
+        }
+        for a in &mut mean {
+            *a /= f64::from(samples);
+        }
+        let (mut err, mut norm) = (0.0, 0.0);
+        for (ci, &h) in mean.iter().enumerate() {
+            let h_ref = h_ex(topo.centroid[ci][0]);
+            err += (h - h_ref).abs() * topo.area[ci];
+            norm += h_ref * topo.area[ci];
+        }
+        assert!(
+            err / norm < 0.025,
+            "MacDonald subcritical relative L1 depth error {}",
+            err / norm
+        );
+        assert!(
+            m.ledger_error().abs() < 1e-6 * m.storage(),
+            "mass error {}",
+            m.ledger_error()
+        );
+    }
+
     /// §15.5: a series-driven slot is a wall until its first
     /// resolution, and conveys from then on.
     #[test]
@@ -1989,6 +2281,81 @@ mod tests {
             (out / expect - 1.0).abs() < 0.10,
             "clamped outflow {out} vs {expect}"
         );
+    }
+
+    /// §15.4.5: the same march, serial and across the team, writes
+    /// byte-identical state — the §6.4 width contract, held for the
+    /// surface. The case is big enough that the team genuinely engages
+    /// (faces and cells both above the dispatch grain) and busy enough
+    /// that every phase does real work: a dam break over a graded
+    /// strip, rain, an evaporating film, and a normal-flow outlet,
+    /// marched through tier rebuilds.
+    #[cfg(feature = "threads")]
+    #[test]
+    fn the_march_is_byte_identical_at_width() {
+        let build_case = || {
+            let mut mesh = graded_strip(100, 12, 1.0, 1.02);
+            let topo = Topology::build(&mesh).expect("valid");
+            let cells = std::mem::take(&mut mesh.cells);
+            mesh.cells = cells
+                .into_iter()
+                .enumerate()
+                .map(|(ci, mut c)| {
+                    if topo.centroid[ci][0] < 10.0 {
+                        c.h0 = 1.0;
+                    }
+                    c
+                })
+                .collect();
+            for ci in 0..mesh.cells.len() {
+                for e in 0..3usize {
+                    let slot = ci * 3 + e;
+                    if topo.neighbour[slot].is_none() && topo.edge_mid[slot][0] < 1e-9 {
+                        mesh.boundaries.push(crate::overland::BoundaryRow {
+                            cell: ci as u32,
+                            edge: e as u8,
+                            condition: BoundaryCondition::NormalFlow { slope: 0.005 },
+                            group: None,
+                        });
+                    }
+                }
+            }
+            let mut m = build(&mesh);
+            for r in &mut m.rain {
+                *r = 1e-5;
+            }
+            for ev in &mut m.evap {
+                *ev = 1e-6;
+            }
+            m
+        };
+        let mut serial = build_case();
+        for _ in 0..12 {
+            serial.advance(5.0);
+        }
+        for width in [3usize, 4] {
+            let mut teamed = build_case();
+            teamed.set_width(width);
+            assert!(
+                teamed.faces.len() >= PAR_GRAIN * width,
+                "the case must be big enough to engage the team"
+            );
+            for _ in 0..12 {
+                teamed.advance(5.0);
+            }
+            let bits = |v: &[f64]| v.iter().map(|x| x.to_bits()).collect::<Vec<_>>();
+            assert_eq!(bits(&serial.vol), bits(&teamed.vol), "vol at width {width}");
+            assert_eq!(bits(&serial.eta), bits(&teamed.eta), "eta at width {width}");
+            assert_eq!(bits(&serial.q), bits(&teamed.q), "q at width {width}");
+            assert_eq!(bits(&serial.qcx), bits(&teamed.qcx), "qcx at width {width}");
+            assert_eq!(
+                serial.rain_in.to_bits(),
+                teamed.rain_in.to_bits(),
+                "rain ledger at width {width}"
+            );
+            assert_eq!(serial.evap_out.to_bits(), teamed.evap_out.to_bits());
+            assert_eq!(serial.boundary_out.to_bits(), teamed.boundary_out.to_bits());
+        }
     }
 
     /// §15.6: a vertex row collapses to the lowest-bed incident cell,

--- a/crates/engine-uds/src/overland/marcher.rs
+++ b/crates/engine-uds/src/overland/marcher.rs
@@ -151,6 +151,17 @@ pub struct Marcher {
     tier: Vec<u8>,
     /// A face fires at the finer of its two cells' cadences.
     face_tier: Vec<u8>,
+    /// §15.4.4: the members of each tier, index-sorted — a substep
+    /// touches only the due tiers' lists instead of scanning the mesh
+    /// (the scan was measured as the sparse case's whole cost).
+    cells_by_tier: Vec<Vec<u32>>,
+    faces_by_tier: Vec<Vec<u32>>,
+    /// The active cells, index-sorted — the §15.4.4 stable-step scan
+    /// and the accumulator settle walk this instead of the mesh.
+    active_list: Vec<u32>,
+    /// §15.4.4: seconds of source integration owed to inactive cells
+    /// since their last lazy sync.
+    lazy_owed: f64,
     macro_cycles: u64,
     /// §15.4.4 whole-run counts for the §14.9 time-step summary.
     substeps: u64,
@@ -523,6 +534,10 @@ impl Marcher {
             active: vec![false; nc],
             tier: vec![0; nc],
             face_tier: Vec::new(),
+            cells_by_tier: Vec::new(),
+            faces_by_tier: Vec::new(),
+            active_list: Vec::new(),
+            lazy_owed: 0.0,
             macro_cycles: 0,
             substeps: 0,
             rebuilds: 0,
@@ -563,6 +578,7 @@ impl Marcher {
         m.face_tier = vec![0; m.faces.len()];
         m.refresh_perot();
         m.rebuild_active();
+        m.rebuild_tier_lists();
         m.rebuilds = 0;
         m.storage0 = m.storage();
         m
@@ -666,7 +682,13 @@ impl Marcher {
             }
         }
         self.rebuilds += 1;
-        self.peak_active = self.peak_active.max(next.iter().filter(|a| **a).count());
+        self.active_list.clear();
+        for (ci, on) in next.iter().enumerate() {
+            if *on {
+                self.active_list.push(ci as u32);
+            }
+        }
+        self.peak_active = self.peak_active.max(self.active_list.len());
         self.active = next;
     }
 
@@ -687,8 +709,9 @@ impl Marcher {
 
     /// §15.4.4: the stable base step over active cells.
     fn stable_dt(&self) -> f64 {
-        (0..self.area.len())
-            .map(|ci| self.cell_dt(ci))
+        self.active_list
+            .iter()
+            .map(|&ci| self.cell_dt(ci as usize))
             .fold(self.max_dt, f64::min)
     }
 
@@ -933,7 +956,11 @@ impl Marcher {
     /// in-flight accumulators, so gather every pending side into its
     /// cell first, and re-close the cells that changed.
     fn settle_accumulators(&mut self) {
-        for ci in 0..self.area.len() {
+        // §15.4.2's both-active rule means deposits land only in cells
+        // that were active when their faces fired — the current list,
+        // since settling precedes every re-activation.
+        for li in 0..self.active_list.len() {
+            let ci = self.active_list[li] as usize;
             let lo = self.cf_off[ci] as usize;
             let hi = self.cf_off[ci + 1] as usize;
             let mut pending = 0.0;
@@ -987,6 +1014,73 @@ impl Marcher {
             if !(self.active[f.cl as usize] && self.active[f.cr as usize]) {
                 self.q[fi] = 0.0;
             }
+        }
+        self.rebuild_tier_lists();
+    }
+
+    /// Rebuild the per-tier membership lists from the current tiers.
+    /// Only active cells march (§15.4.4 — inactive cells integrate
+    /// their sources lazily as pure storage between rebuilds), and only
+    /// both-active faces convey. Index order within each list keeps
+    /// every downstream traversal deterministic.
+    fn rebuild_tier_lists(&mut self) {
+        let k = self.lts_tiers.saturating_sub(1).min(7) as usize + 1;
+        // Reuse the buffers: a coupled run rebuilds every advance, and
+        // the reallocation was measurable churn.
+        self.cells_by_tier.resize(k, Vec::new());
+        self.faces_by_tier.resize(k, Vec::new());
+        for l in &mut self.cells_by_tier {
+            l.clear();
+        }
+        for l in &mut self.faces_by_tier {
+            l.clear();
+        }
+        for &ci in &self.active_list {
+            self.cells_by_tier[self.tier[ci as usize] as usize].push(ci);
+        }
+        for (fi, &t) in self.face_tier.iter().enumerate() {
+            let f = &self.faces[fi];
+            if self.active[f.cl as usize] && self.active[f.cr as usize] {
+                self.faces_by_tier[t as usize].push(fi as u32);
+            }
+        }
+    }
+
+    /// §15.4.4: integrate the sources owed to inactive cells as pure
+    /// storage — rain and held injection in, ramped evaporation out —
+    /// booking exactly as the firing path books. Runs at every rebuild
+    /// (before the active set is recomputed, so an accumulating film
+    /// activates on schedule) and at the end of every advance.
+    fn integrate_lazy_sources(&mut self) {
+        if self.lazy_owed <= 0.0 {
+            return;
+        }
+        let dt = self.lazy_owed;
+        self.lazy_owed = 0.0;
+        for ci in 0..self.area.len() {
+            if self.active[ci] {
+                continue;
+            }
+            let a = self.area[ci];
+            let rain = self.rain[ci] * a * dt;
+            let coup = self.coupling[ci] * a * dt;
+            let t = (self.depth[ci] / self.dry_depth).clamp(0.0, 1.0);
+            let ramp = t * t * (3.0 - 2.0 * t);
+            let want = self.evap[ci] * ramp * a * dt;
+            if rain == 0.0 && coup == 0.0 && want == 0.0 {
+                continue;
+            }
+            let before = self.vol[ci] + rain + coup;
+            let take = want.min(before.max(0.0));
+            self.rain_in += rain;
+            if coup >= 0.0 {
+                self.outfall_in += coup;
+            } else {
+                self.outfall_out += -coup;
+            }
+            self.evap_out += take;
+            self.vol[ci] = (before - take).max(0.0);
+            self.reclose(ci);
         }
     }
 
@@ -1071,32 +1165,47 @@ impl Marcher {
         let mut q = std::mem::take(&mut self.q);
         let mut fl = std::mem::take(&mut self.facc_l);
         let mut fr = std::mem::take(&mut self.facc_r);
+        let lists = std::mem::take(&mut self.faces_by_tier);
         let (qp, flp, frp) = (q.as_mut_ptr(), fl.as_mut_ptr(), fr.as_mut_ptr());
-        #[cfg(feature = "threads")]
-        {
-            if let Some(mut team) = self.team.take() {
-                if self.faces.len() >= PAR_GRAIN * team.width() {
-                    use crate::hydraulics::team::SendPtr;
-                    let (qs, fls, frs) = (SendPtr::new(qp), SendPtr::new(flp), SendPtr::new(frp));
-                    let me = &*self;
-                    // SAFETY: per-face disjoint reads/writes, as the
-                    // body's contract states.
-                    team.run(me.faces.len(), |fi| unsafe {
-                        me.fire_face_at(fi, dt0, s, qs.get(), fls.get(), frs.get());
-                    });
+        for (k, list) in lists.iter().enumerate() {
+            if !s.is_multiple_of(1u64 << k) || list.is_empty() {
+                continue;
+            }
+            #[cfg(feature = "threads")]
+            {
+                let mut teamed = false;
+                if let Some(mut team) = self.team.take() {
+                    if list.len() >= PAR_GRAIN * team.width() {
+                        use crate::hydraulics::team::SendPtr;
+                        let (qs, fls, frs) =
+                            (SendPtr::new(qp), SendPtr::new(flp), SendPtr::new(frp));
+                        let me = &*self;
+                        // SAFETY: per-face disjoint reads/writes, as
+                        // the body's contract states.
+                        team.run(list.len(), |i| unsafe {
+                            me.fire_face_at(
+                                list[i] as usize,
+                                dt0,
+                                s,
+                                qs.get(),
+                                fls.get(),
+                                frs.get(),
+                            );
+                        });
+                        teamed = true;
+                    }
                     self.team = Some(team);
-                    self.q = q;
-                    self.facc_l = fl;
-                    self.facc_r = fr;
-                    return;
                 }
-                self.team = Some(team);
+                if teamed {
+                    continue;
+                }
+            }
+            for &fi in list {
+                // SAFETY: serial — the pointers are exclusive here.
+                unsafe { self.fire_face_at(fi as usize, dt0, s, qp, flp, frp) };
             }
         }
-        for fi in 0..self.faces.len() {
-            // SAFETY: serial — the pointers are exclusive here.
-            unsafe { self.fire_face_at(fi, dt0, s, qp, flp, frp) };
-        }
+        self.faces_by_tier = lists;
         self.q = q;
         self.facc_l = fl;
         self.facc_r = fr;
@@ -1180,32 +1289,39 @@ impl Marcher {
             fr: fr.as_mut_ptr(),
             led: led.as_mut_ptr(),
         };
-        // `mut` only when the team path can set it.
-        #[cfg_attr(not(feature = "threads"), allow(unused_mut))]
-        let mut ran = false;
-        #[cfg(feature = "threads")]
-        {
-            if let Some(mut team) = self.team.take() {
-                if nc >= PAR_GRAIN * team.width() {
-                    let shared = &ptrs;
-                    let me = &*self;
-                    // SAFETY: per-cell disjoint reads/writes — a cell
-                    // touches only its own slots and its own sides of
-                    // its incident faces' accumulators.
-                    team.run(nc, |ci| unsafe {
-                        me.fire_cell_at(ci, dt0, s, shared);
-                    });
-                    ran = true;
+        let _ = nc;
+        let lists = std::mem::take(&mut self.cells_by_tier);
+        for (k, list) in lists.iter().enumerate() {
+            if !s.is_multiple_of(1u64 << k) || list.is_empty() {
+                continue;
+            }
+            #[cfg(feature = "threads")]
+            {
+                let mut teamed = false;
+                if let Some(mut team) = self.team.take() {
+                    if list.len() >= PAR_GRAIN * team.width() {
+                        let shared = &ptrs;
+                        let me = &*self;
+                        // SAFETY: per-cell disjoint reads/writes — a
+                        // cell touches only its own slots and its own
+                        // sides of its incident faces' accumulators.
+                        team.run(list.len(), |i| unsafe {
+                            me.fire_cell_at(list[i] as usize, dt0, s, shared);
+                        });
+                        teamed = true;
+                    }
+                    self.team = Some(team);
                 }
-                self.team = Some(team);
+                if teamed {
+                    continue;
+                }
             }
-        }
-        if !ran {
-            for ci in 0..nc {
+            for &ci in list {
                 // SAFETY: serial — the pointers are exclusive here.
-                unsafe { self.fire_cell_at(ci, dt0, s, &ptrs) };
+                unsafe { self.fire_cell_at(ci as usize, dt0, s, &ptrs) };
             }
         }
+        self.cells_by_tier = lists;
         self.vol = vol;
         self.depth = depth;
         self.eta = eta;
@@ -1214,21 +1330,26 @@ impl Marcher {
         self.facc_l = fl;
         self.facc_r = fr;
         self.led = led;
-        // §15.8: the ledger reduction, serial and in index order.
-        for ci in 0..nc {
-            if !s.is_multiple_of(1u64 << self.tier[ci]) {
+        // §15.8: the ledger reduction — serial, tiers ascending, index
+        // order within each tier, so the sums are deterministic at any
+        // width.
+        for k in 0..self.cells_by_tier.len() {
+            if !s.is_multiple_of(1u64 << k) {
                 continue;
             }
-            let [rain, coup, take] = self.led[ci];
-            self.rain_in += rain;
-            // The injection path books separately from the junction
-            // orifice exchange.
-            if coup >= 0.0 {
-                self.outfall_in += coup;
-            } else {
-                self.outfall_out += -coup;
+            for i in 0..self.cells_by_tier[k].len() {
+                let ci = self.cells_by_tier[k][i] as usize;
+                let [rain, coup, take] = self.led[ci];
+                self.rain_in += rain;
+                // The injection path books separately from the
+                // junction orifice exchange.
+                if coup >= 0.0 {
+                    self.outfall_in += coup;
+                } else {
+                    self.outfall_out += -coup;
+                }
+                self.evap_out += take;
             }
-            self.evap_out += take;
         }
     }
 
@@ -1368,6 +1489,7 @@ impl Marcher {
             // integrates exactly nsub·dt0 per cycle.
             if self.macro_cycles.is_multiple_of(4) {
                 self.settle_accumulators();
+                self.integrate_lazy_sources();
                 self.rebuild_active();
                 dt0 = self.stable_dt();
                 self.assign_tiers(dt0);
@@ -1384,6 +1506,7 @@ impl Marcher {
                 for t in &mut self.face_tier {
                     *t = 0;
                 }
+                self.rebuild_tier_lists();
                 while remaining > 1e-12 {
                     let dt = dt0.min(remaining);
                     self.fire_faces(dt, 0);
@@ -1393,6 +1516,7 @@ impl Marcher {
                     self.substeps += 1;
                     self.min_dt0 = self.min_dt0.min(dt);
                     self.advanced += dt;
+                    self.lazy_owed += dt;
                     remaining -= dt;
                 }
                 self.macro_cycles += 1;
@@ -1407,9 +1531,13 @@ impl Marcher {
             self.substeps += nsub;
             self.min_dt0 = self.min_dt0.min(dt0);
             self.advanced += dt0 * nsub as f64;
+            self.lazy_owed += dt0 * nsub as f64;
             remaining -= dt0 * nsub as f64;
             self.macro_cycles += 1;
         }
+        // §15.4.4: an advance returns with every cell at the target
+        // time, the lazily integrated ones included.
+        self.integrate_lazy_sources();
     }
 
     /// §15.4.4 whole-run march counts for the §14.9 time-step summary:
@@ -2282,6 +2410,74 @@ mod tests {
         assert!(
             (out / expect - 1.0).abs() < 0.10,
             "clamped outflow {out} vs {expect}"
+        );
+    }
+
+    /// Not a gate: a coarse wall-clock probe for performance passes.
+    /// Run with `cargo test --release -- --ignored marcher_performance`.
+    #[test]
+    #[ignore = "manual performance probe"]
+    fn marcher_performance_probe() {
+        let (nx, ny) = (250usize, 240usize);
+        // A: a dam break engaging most of the mesh.
+        let mut mesh = grid(nx, ny, 1.0, |x, _| 10.0 + 0.002 * x);
+        let topo = Topology::build(&mesh).expect("valid");
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .enumerate()
+            .map(|(ci, mut c)| {
+                if topo.centroid[ci][0] < 20.0 {
+                    c.h0 = 1.0;
+                }
+                c
+            })
+            .collect();
+        let mut m = build(&mesh);
+        let t0 = std::time::Instant::now();
+        m.advance(60.0);
+        let (sub, cyc, reb, mn, av, peak) = m.statistics();
+        println!(
+            "A dam-break {}c {}f: {:.2?}  substeps {sub} cycles {cyc} rebuilds {reb} dt {mn:.4}/{av:.4} peak {peak}",
+            m.area.len(),
+            m.faces.len(),
+            t0.elapsed()
+        );
+        #[cfg(feature = "threads")]
+        for width in [4usize, 8] {
+            let mut m = build(&mesh);
+            m.set_width(width);
+            let t0 = std::time::Instant::now();
+            m.advance(60.0);
+            println!("A dam-break width {width}: {:.2?}", t0.elapsed());
+        }
+
+        // B: a small pond on a large dry mesh — the sparse case the
+        // active set exists for.
+        let mut mesh = grid(nx, ny, 1.0, |x, y| {
+            10.0 + 0.002 * x + ((x - 20.0).hypot(y - 20.0) / 10.0).min(3.0) * 0.0
+        });
+        let topo = Topology::build(&mesh).expect("valid");
+        let cells = std::mem::take(&mut mesh.cells);
+        mesh.cells = cells
+            .into_iter()
+            .enumerate()
+            .map(|(ci, mut c)| {
+                let (x, y) = (topo.centroid[ci][0], topo.centroid[ci][1]);
+                if (x - 20.0).hypot(y - 20.0) < 10.0 {
+                    c.h0 = 0.3;
+                }
+                c
+            })
+            .collect();
+        let mut m = build(&mesh);
+        let t0 = std::time::Instant::now();
+        m.advance(600.0);
+        let (sub, cyc, reb, mn, av, peak) = m.statistics();
+        println!(
+            "B sparse {}c: {:.2?}  substeps {sub} cycles {cyc} rebuilds {reb} dt {mn:.4}/{av:.4} peak {peak}",
+            m.area.len(),
+            t0.elapsed()
         );
     }
 

--- a/crates/engine-uds/src/overland/meteorology.rs
+++ b/crates/engine-uds/src/overland/meteorology.rs
@@ -1,0 +1,385 @@
+//! §15.7: rainfall interpolation to cell centroids.
+//!
+//! `NATURAL_NEIGHBOUR` builds Laplace (non-Sibsonian) natural-neighbour
+//! weights over the located gauges' Delaunay triangulation, falling
+//! back per cell to inverse-distance-squared outside the convex hull.
+//! Degenerate gauge sets degrade exactly as the spec's ladder says: one
+//! gauge serves everywhere, collinear or paired gauges serve by inverse
+//! distance, and no located gauge leaves the table unready — the caller
+//! then applies the `SYSTEM` mean. Weights are precomputed once.
+
+#[derive(Debug, Clone, Copy)]
+struct Pt {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Tri {
+    a: usize,
+    b: usize,
+    c: usize,
+}
+
+fn orient2d(a: Pt, b: Pt, c: Pt) -> f64 {
+    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+fn dist2(p: Pt, q: Pt) -> f64 {
+    let (dx, dy) = (p.x - q.x, p.y - q.y);
+    dx * dx + dy * dy
+}
+
+/// Circumcentre; the caller guards the collinear case.
+fn circumcentre(a: Pt, b: Pt, c: Pt) -> Pt {
+    let d = 2.0 * (a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y));
+    let a2 = a.x * a.x + a.y * a.y;
+    let b2 = b.x * b.x + b.y * b.y;
+    let c2 = c.x * c.x + c.y * c.y;
+    Pt {
+        x: (a2 * (b.y - c.y) + b2 * (c.y - a.y) + c2 * (a.y - b.y)) / d,
+        y: (a2 * (c.x - b.x) + b2 * (a.x - c.x) + c2 * (b.x - a.x)) / d,
+    }
+}
+
+/// Strictly inside the circumcircle of CCW (a, b, c).
+fn in_circle(a: Pt, b: Pt, c: Pt, p: Pt) -> bool {
+    let (ax, ay) = (a.x - p.x, a.y - p.y);
+    let (bx, by) = (b.x - p.x, b.y - p.y);
+    let (cx, cy) = (c.x - p.x, c.y - p.y);
+    (ax * ax + ay * ay) * (bx * cy - cx * by) - (bx * bx + by * by) * (ax * cy - cx * ay)
+        + (cx * cx + cy * cy) * (ax * by - bx * ay)
+        > 0.0
+}
+
+/// Boundary directed edges of a cavity: an edge is on the boundary when
+/// its reverse is not also a cavity edge. Cavities are tiny; O(n²) is
+/// fine.
+fn cavity_boundary(bad: &[[usize; 2]]) -> Vec<[usize; 2]> {
+    bad.iter()
+        .filter(|e| !bad.iter().any(|f| f[0] == e[1] && f[1] == e[0]))
+        .copied()
+        .collect()
+}
+
+/// Bowyer–Watson Delaunay triangulation, or empty when the sites are
+/// degenerate (coincident or collinear) — the caller falls back to IDW.
+fn delaunay(site: &[Pt]) -> Vec<Tri> {
+    let m = site.len();
+    if m < 3 {
+        return Vec::new();
+    }
+    let (mut minx, mut maxx, mut miny, mut maxy) = (site[0].x, site[0].x, site[0].y, site[0].y);
+    for s in site {
+        minx = minx.min(s.x);
+        maxx = maxx.max(s.x);
+        miny = miny.min(s.y);
+        maxy = maxy.max(s.y);
+    }
+    let dmax = (maxx - minx).max(maxy - miny);
+    if dmax <= 0.0 {
+        return Vec::new();
+    }
+    let mut pts: Vec<Pt> = site.to_vec();
+    let (midx, midy) = (0.5 * (minx + maxx), 0.5 * (miny + maxy));
+    let r = 20.0 * dmax;
+    pts.push(Pt {
+        x: midx - 2.0 * r,
+        y: midy - r,
+    });
+    pts.push(Pt {
+        x: midx + 2.0 * r,
+        y: midy - r,
+    });
+    pts.push(Pt {
+        x: midx,
+        y: midy + 2.0 * r,
+    });
+    let ccw = |a: usize, b: usize, c: usize, pts: &[Pt]| {
+        if orient2d(pts[a], pts[b], pts[c]) < 0.0 {
+            Tri { a, b: c, c: b }
+        } else {
+            Tri { a, b, c }
+        }
+    };
+    let mut tris = vec![ccw(m, m + 1, m + 2, &pts)];
+    for i in 0..m {
+        let p = pts[i];
+        let mut bad: Vec<[usize; 2]> = Vec::new();
+        let mut good: Vec<Tri> = Vec::with_capacity(tris.len());
+        for t in &tris {
+            if in_circle(pts[t.a], pts[t.b], pts[t.c], p) {
+                bad.push([t.a, t.b]);
+                bad.push([t.b, t.c]);
+                bad.push([t.c, t.a]);
+            } else {
+                good.push(*t);
+            }
+        }
+        tris = good;
+        for e in cavity_boundary(&bad) {
+            tris.push(ccw(e[0], e[1], i, &pts));
+        }
+    }
+    tris.retain(|t| t.a < m && t.b < m && t.c < m);
+    tris
+}
+
+/// Inverse-distance-squared weights over every located site.
+fn idw_all(p: Pt, site: &[Pt]) -> Vec<(usize, f64)> {
+    for (j, s) in site.iter().enumerate() {
+        if dist2(p, *s) < 1e-18 {
+            return vec![(j, 1.0)];
+        }
+    }
+    let mut w: Vec<(usize, f64)> = site
+        .iter()
+        .enumerate()
+        .map(|(j, s)| (j, 1.0 / dist2(p, *s)))
+        .collect();
+    let sum: f64 = w.iter().map(|e| e.1).sum();
+    for e in &mut w {
+        e.1 /= sum;
+    }
+    w
+}
+
+/// Laplace weights at `p`, or empty when `p` lies outside the convex
+/// hull or the construction degenerates — the caller falls back to IDW.
+/// Inserting `p` carves a cavity in the triangulation; the Voronoi
+/// facet between `p` and a cavity-boundary site is bounded by the
+/// circumcentres of the two fan triangles incident to that site, and
+/// the Laplace weight is facet length over site distance.
+fn laplace_weights(p: Pt, site: &[Pt], tris: &[Tri]) -> Vec<(usize, f64)> {
+    for (j, s) in site.iter().enumerate() {
+        if dist2(p, *s) < 1e-18 {
+            return vec![(j, 1.0)];
+        }
+    }
+    let inside = tris.iter().any(|t| {
+        let d0 = orient2d(site[t.a], site[t.b], p);
+        let d1 = orient2d(site[t.b], site[t.c], p);
+        let d2 = orient2d(site[t.c], site[t.a], p);
+        !((d0 < 0.0 || d1 < 0.0 || d2 < 0.0) && (d0 > 0.0 || d1 > 0.0 || d2 > 0.0))
+    });
+    if !inside {
+        return Vec::new();
+    }
+    let mut bad: Vec<[usize; 2]> = Vec::new();
+    for t in tris {
+        if in_circle(site[t.a], site[t.b], site[t.c], p) {
+            bad.push([t.a, t.b]);
+            bad.push([t.b, t.c]);
+            bad.push([t.c, t.a]);
+        }
+    }
+    let boundary = cavity_boundary(&bad);
+    if boundary.is_empty() {
+        return Vec::new();
+    }
+    // Circumcentre of each fan triangle (p, u, v), indexed by tail and
+    // head site.
+    let mut by_tail: Vec<Option<Pt>> = vec![None; site.len()];
+    let mut by_head: Vec<Option<Pt>> = vec![None; site.len()];
+    for e in &boundary {
+        let (u, v) = (site[e[0]], site[e[1]]);
+        if orient2d(p, u, v).abs() < 1e-20 {
+            return Vec::new();
+        }
+        let cc = circumcentre(p, u, v);
+        by_tail[e[0]] = Some(cc);
+        by_head[e[1]] = Some(cc);
+    }
+    let mut w: Vec<(usize, f64)> = Vec::with_capacity(boundary.len());
+    let mut sum = 0.0;
+    for e in &boundary {
+        let s = e[1];
+        let (Some(cin), Some(cout)) = (by_head[s], by_tail[s]) else {
+            return Vec::new();
+        };
+        let facet = dist2(cin, cout).sqrt();
+        let wj = facet / dist2(p, site[s]).sqrt();
+        w.push((s, wj));
+        sum += wj;
+    }
+    if sum <= 0.0 {
+        return Vec::new();
+    }
+    for e in &mut w {
+        e.1 /= sum;
+    }
+    w
+}
+
+/// Precomputed per-cell gauge weights (CSR), gauge indices as the model
+/// numbers them.
+#[derive(Debug, Clone, Default)]
+pub struct RainWeights {
+    ptr: Vec<u32>,
+    gage: Vec<u16>,
+    val: Vec<f64>,
+    ready: bool,
+}
+
+impl RainWeights {
+    /// Build the table from cell centroids and the model's gauge
+    /// positions (`None` = unlocated, excluded). Duplicate positions
+    /// keep only the first — natural neighbour is ill-defined for two
+    /// gauges at one point. With no located gauge the table stays
+    /// unready and the caller applies the `SYSTEM` mean.
+    pub fn build(cx: &[f64], cy: &[f64], gauges: &[Option<(f64, f64)>]) -> RainWeights {
+        let mut site: Vec<Pt> = Vec::new();
+        let mut gid: Vec<usize> = Vec::new();
+        for (g, pos) in gauges.iter().enumerate() {
+            let Some((x, y)) = *pos else { continue };
+            let s = Pt { x, y };
+            if site.iter().any(|e| dist2(*e, s) < 1e-12) {
+                continue;
+            }
+            site.push(s);
+            gid.push(g);
+        }
+        let nc = cx.len();
+        if site.is_empty() || nc == 0 {
+            return RainWeights::default();
+        }
+        let rows: Vec<Vec<(usize, f64)>> = if site.len() == 1 {
+            vec![vec![(0, 1.0)]; nc]
+        } else {
+            let tris = delaunay(&site);
+            (0..nc)
+                .map(|i| {
+                    let p = Pt { x: cx[i], y: cy[i] };
+                    if tris.is_empty() {
+                        idw_all(p, &site)
+                    } else {
+                        let w = laplace_weights(p, &site, &tris);
+                        if w.is_empty() {
+                            idw_all(p, &site)
+                        } else {
+                            w
+                        }
+                    }
+                })
+                .collect()
+        };
+        let mut t = RainWeights {
+            ptr: Vec::with_capacity(nc + 1),
+            gage: Vec::new(),
+            val: Vec::new(),
+            ready: true,
+        };
+        for row in rows {
+            t.ptr.push(t.gage.len() as u32);
+            for (j, w) in row {
+                t.gage.push(gid[j] as u16);
+                t.val.push(w);
+            }
+        }
+        t.ptr.push(t.gage.len() as u32);
+        t
+    }
+
+    /// Whether the table can serve; unready means no gauge is located.
+    pub fn ready(&self) -> bool {
+        self.ready
+    }
+
+    /// Interpolate per-gauge intensities to per-cell rates.
+    pub fn apply(&self, gauge_rain: &[f64], out: &mut [f64]) {
+        for (i, o) in out.iter_mut().enumerate() {
+            let (lo, hi) = (self.ptr[i] as usize, self.ptr[i + 1] as usize);
+            *o = (lo..hi)
+                .map(|k| self.val[k] * gauge_rain[self.gage[k] as usize])
+                .sum();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_at(t: &RainWeights, rain: &[f64], n: usize) -> Vec<f64> {
+        let mut out = vec![0.0; n];
+        t.apply(rain, &mut out);
+        out
+    }
+
+    /// Laplace natural-neighbour weights reproduce a linear field
+    /// exactly inside the gauge hull.
+    #[test]
+    fn linear_fields_are_exact_inside_the_hull() {
+        let gauges = [
+            Some((0.0, 0.0)),
+            Some((10.0, 0.5)),
+            Some((9.5, 9.0)),
+            Some((-0.5, 10.0)),
+            Some((5.0, 4.0)),
+        ];
+        let f = |x: f64, y: f64| 3.0 + 0.7 * x - 0.4 * y;
+        let rain: Vec<f64> = gauges
+            .iter()
+            .map(|g| g.map(|(x, y)| f(x, y)).unwrap_or(0.0))
+            .collect();
+        let cx = [2.0, 5.0, 7.0, 3.3, 6.1];
+        let cy = [3.0, 5.0, 2.0, 6.7, 4.9];
+        let t = RainWeights::build(&cx, &cy, &gauges);
+        assert!(t.ready());
+        let out = apply_at(&t, &rain, cx.len());
+        for i in 0..cx.len() {
+            let exact = f(cx[i], cy[i]);
+            assert!(
+                (out[i] - exact).abs() < 1e-9,
+                "cell {i}: {} vs {exact}",
+                out[i]
+            );
+        }
+    }
+
+    /// The degradation ladder: one gauge serves everywhere; two serve
+    /// by inverse distance; collinear sets serve by inverse distance;
+    /// no located gauge leaves the table unready.
+    #[test]
+    fn degenerate_gauge_sets_degrade_as_specified() {
+        let cx = [0.0, 3.0];
+        let cy = [0.0, 4.0];
+        let one = RainWeights::build(&cx, &cy, &[None, Some((50.0, 50.0))]);
+        assert!(one.ready());
+        assert_eq!(apply_at(&one, &[0.0, 7.0], 2), vec![7.0, 7.0]);
+
+        let two = RainWeights::build(&cx, &cy, &[Some((0.0, 0.0)), Some((0.0, 8.0))]);
+        // Cell 0 sits on the first gauge: exact hit. Cell 1 is 5 m from
+        // both: even split.
+        let out = apply_at(&two, &[2.0, 6.0], 2);
+        assert!((out[0] - 2.0).abs() < 1e-12);
+        assert!((out[1] - 4.0).abs() < 1e-12);
+
+        let collinear = RainWeights::build(
+            &[1.0],
+            &[1.0],
+            &[Some((0.0, 0.0)), Some((5.0, 0.0)), Some((10.0, 0.0))],
+        );
+        assert!(collinear.ready());
+        let out = apply_at(&collinear, &[1.0, 1.0, 1.0], 1);
+        assert!((out[0] - 1.0).abs() < 1e-12, "IDW of a uniform field");
+
+        let none = RainWeights::build(&cx, &cy, &[None, None]);
+        assert!(!none.ready());
+    }
+
+    /// Outside the hull the weights fall back to inverse distance
+    /// squared: positive, normalised, nearest-dominated.
+    #[test]
+    fn outside_the_hull_is_inverse_distance() {
+        let gauges = [Some((0.0, 0.0)), Some((10.0, 0.0)), Some((5.0, 8.0))];
+        let t = RainWeights::build(&[5.0, -10.0], &[3.0, 0.0], &gauges);
+        // Interior cell: natural-neighbour, exact for the constant.
+        // Exterior cell at (-10, 0): closest to gauge 0.
+        let out = apply_at(&t, &[1.0, 1.0, 1.0], 2);
+        assert!((out[0] - 1.0).abs() < 1e-12);
+        assert!((out[1] - 1.0).abs() < 1e-12, "weights normalise");
+        let spike = apply_at(&t, &[1.0, 0.0, 0.0], 2);
+        assert!(spike[1] > 0.5, "the nearest gauge dominates outside");
+    }
+}

--- a/crates/engine-uds/src/overland/mod.rs
+++ b/crates/engine-uds/src/overland/mod.rs
@@ -1,0 +1,707 @@
+#![doc = include_str!("spec.md")]
+
+//! The overland surface: the §15.2 mesh model, its derived topology, and
+//! its validation. The marcher (§15.4) and couplings (§15.6) build on
+//! these in later phases; until they land, §1.8 governs what a model
+//! carrying a mesh receives.
+
+/// The authored overland surface (§15.2, §14.15), in SI after import.
+///
+/// Everything here is what the file said, converted and index-resolved,
+/// before any topology is derived: derivation and validation live in
+/// [`Topology::build`], so a session can report authoring defects with
+/// the author's own vocabulary and derived defects with the mesh's.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct OverlandMesh {
+    /// Mesh vertices in authoring order: position and ground elevation
+    /// (m), and the optional identifying tag.
+    pub verts: Vec<MeshVertex>,
+    /// Cells in authoring order.
+    pub cells: Vec<MeshCell>,
+    /// §14.15 solver options, defaults applied.
+    pub options: OverlandOptions,
+    /// Vertex-coupling rows (§15.6): one per vertex, later rows replace.
+    pub vertex_couplings: Vec<CouplingRow>,
+    /// Cell-coupling rows (§15.6): rows accumulate, several nodes may
+    /// couple to one cell.
+    pub cell_couplings: Vec<CouplingRow>,
+    /// Boundary-condition rows (§15.5), in file order.
+    pub boundaries: Vec<BoundaryRow>,
+    /// Edge-conveyance rows (§15.2): undirected vertex pair and ψ.
+    pub conveyance: Vec<ConveyanceRow>,
+    /// Initial cell velocities (§14.15): cell index and (u, v) in m/s.
+    pub init_velocity: Vec<InitVelocityRow>,
+    /// Whether the mesh declared itself SI (`;; UNITS: SI (m)`), which
+    /// skips display-unit conversion at import (§14.15).
+    pub units_si: bool,
+    /// The external mesh file's name, when `[2D_MESH_FILE]` declared one
+    /// (§14.15). The caller supplies its text; the name is what a
+    /// refusal or survey reports.
+    pub mesh_file: Option<String>,
+}
+
+/// One §14.15 initial-velocity row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InitVelocityRow {
+    pub cell: u32,
+    /// (u, v) in m/s, as authored — velocities are SI in every unit
+    /// system, as the predecessor reads them.
+    pub u: f64,
+    pub v: f64,
+}
+
+/// One mesh vertex (§15.2).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MeshVertex {
+    pub x: f64,
+    pub y: f64,
+    /// Ground elevation (m).
+    pub z: f64,
+    pub tag: Option<String>,
+}
+
+/// One mesh cell (§15.2).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MeshCell {
+    /// Vertex indices; winding order free.
+    pub v: [u32; 3],
+    /// Manning roughness (> 0).
+    pub n: f64,
+    /// Initial depth (m, ≥ 0).
+    pub h0: f64,
+    pub tag: Option<String>,
+}
+
+/// One §15.6 coupling row: a mesh vertex or cell joined to a network
+/// vertex, with its discharge coefficient and exchange area.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CouplingRow {
+    /// Mesh vertex or cell index (per the owning list).
+    pub mesh_index: u32,
+    /// The coupled network vertex, as the model names it; resolved at
+    /// build against §2.6 identifiers.
+    pub node: String,
+    /// Discharge coefficient (§15.6), default 0.65.
+    pub cd: f64,
+    /// Exchange area (m²), default 1.0.
+    pub area: f64,
+    /// Whether the row authored its own area — an unauthored one is
+    /// eligible for `COUPLING_AREA AUTO` derivation (§15.6).
+    pub area_authored: bool,
+}
+
+/// One §15.5 boundary row: the condition attached to a cell's local edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoundaryRow {
+    pub cell: u32,
+    /// Local edge 0..=2, opposite the same-numbered vertex (§15.2).
+    pub edge: u8,
+    pub condition: BoundaryCondition,
+    /// The optional named group, carried but semantically inert (§14.15).
+    pub group: Option<String>,
+}
+
+/// A §15.5 boundary condition as authored.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BoundaryCondition {
+    Wall,
+    /// Manning outfall at the authored bed slope.
+    NormalFlow {
+        slope: f64,
+    },
+    /// A held stage (m, elevation datum).
+    Stage(SeriesOrValue),
+    /// A held per-metre discharge (m³/s per metre of edge, outward
+    /// positive as authored; §15.5 applies it as an inflow sign).
+    Flow(SeriesOrValue),
+    /// Per-metre discharge from a curve of stage above the edge bed.
+    RatingCurve {
+        curve: String,
+    },
+}
+
+/// A boundary parameter: a constant, or a named time series resolved at
+/// build (§14.15).
+#[derive(Debug, Clone, PartialEq)]
+pub enum SeriesOrValue {
+    Value(f64),
+    Series(String),
+}
+
+/// One §15.2 edge-conveyance row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConveyanceRow {
+    pub from: u32,
+    pub to: u32,
+    /// ψ ∈ [0, 1].
+    pub factor: f64,
+}
+
+/// §14.15 `[2D_OPTIONS]`, defaults applied at construction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OverlandOptions {
+    pub cfl_number: f64,
+    pub max_timestep: f64,
+    pub theta: f64,
+    pub froude_max: f64,
+    pub lts_tiers: u32,
+    pub h_move: f64,
+    pub dry_depth: f64,
+    pub cell_closure: CellClosure,
+    pub face_reconstruction: FaceReconstruction,
+    pub vfr_min_wet_frac: f64,
+    pub advection: bool,
+    pub rainfall_mode: RainfallMode,
+    pub coupling_area_auto: bool,
+    pub coupling_cd: f64,
+    pub coupling_sync: f64,
+    pub report_2d: bool,
+    pub output_file: Option<String>,
+}
+
+impl Default for OverlandOptions {
+    fn default() -> Self {
+        OverlandOptions {
+            cfl_number: 0.7,
+            max_timestep: 10.0,
+            theta: 0.8,
+            froude_max: 1.5,
+            lts_tiers: 4,
+            h_move: 0.003,
+            dry_depth: 0.001,
+            cell_closure: CellClosure::Flat,
+            face_reconstruction: FaceReconstruction::Mean,
+            vfr_min_wet_frac: 0.01,
+            advection: false,
+            rainfall_mode: RainfallMode::NaturalNeighbour,
+            coupling_area_auto: false,
+            coupling_cd: 0.65,
+            coupling_sync: 0.0,
+            report_2d: true,
+            output_file: None,
+        }
+    }
+}
+
+/// §15.3 cell stage–storage closure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellClosure {
+    Flat,
+    Vfr,
+}
+
+/// §15.3 face-depth reconstruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaceReconstruction {
+    Mean,
+    VfrFace,
+}
+
+/// §15.7 rainfall-to-mesh mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RainfallMode {
+    NaturalNeighbour,
+    System,
+    None,
+}
+
+/// The derived mesh topology (§15.2): adjacency, geometry, and the
+/// per-edge quantities the marcher reads. Built once from a validated
+/// [`OverlandMesh`]; building is also where §15.2's validation runs,
+/// because most of what it checks is only visible derived.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Topology {
+    /// Cell centroids (x, y) and the centroid bed elevation z̄ (m).
+    pub centroid: Vec<[f64; 3]>,
+    /// Cell planimetric areas (m²), strictly positive.
+    pub area: Vec<f64>,
+    /// Neighbour cell across local edge `cell*3 + e`; `None` at the
+    /// domain boundary.
+    pub neighbour: Vec<Option<u32>>,
+    /// Edge planimetric lengths (m), flat `cell*3 + e`.
+    pub edge_len: Vec<f64>,
+    /// Outward unit normals, flat `cell*3 + e`.
+    pub edge_normal: Vec<[f64; 2]>,
+    /// Edge midpoints (x, y), flat `cell*3 + e`.
+    pub edge_mid: Vec<[f64; 2]>,
+    /// Sorted endpoint bed elevations (z_lo, z_hi) per edge, flat.
+    pub edge_z: Vec<[f64; 2]>,
+    /// Inverse centroid-to-centroid normal distance 1/dₙ per interior
+    /// edge slot (§15.2's slivered-cell floor applied); 0 at boundary
+    /// slots, where §15.5's own arm applies.
+    pub inv_dn: Vec<f64>,
+    /// Conveyance ψ per edge slot, both slots of an interior edge equal.
+    pub conveyance: Vec<f64>,
+}
+
+/// A §15.2 mesh defect, named with the author's vocabulary.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MeshError {
+    /// Fewer than three vertices or no cells.
+    TooSmall { verts: usize, cells: usize },
+    /// A cell names a vertex the mesh does not have.
+    VertexOutOfRange { cell: usize, vertex: u32 },
+    /// A cell repeats a vertex.
+    DegenerateCell { cell: usize },
+    /// A cell's planimetric area is not strictly positive.
+    ZeroArea { cell: usize },
+    /// A cell's Manning roughness is not strictly positive.
+    BadRoughness { cell: usize, n: f64 },
+    /// A cell's initial depth is negative.
+    NegativeDepth { cell: usize },
+    /// A conveyance row's factor is outside [0, 1].
+    BadConveyance { from: u32, to: u32, factor: f64 },
+    /// A conveyance row names an edge no cell pair shares.
+    UnknownEdge { from: u32, to: u32 },
+    /// A conveyance row joins a vertex to itself.
+    SelfEdge { vertex: u32 },
+    /// An edge is claimed by more than two cells: the surface is not a
+    /// manifold there.
+    NonManifoldEdge { from: u32, to: u32 },
+    /// A boundary row addresses a cell or edge that does not exist, or
+    /// an interior edge.
+    BadBoundary { cell: u32, edge: u8 },
+}
+
+impl std::fmt::Display for MeshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MeshError::TooSmall { verts, cells } => write!(
+                f,
+                "the mesh needs at least three vertices and one triangle \
+                 (has {verts} and {cells})"
+            ),
+            MeshError::VertexOutOfRange { cell, vertex } => {
+                write!(
+                    f,
+                    "triangle {cell} names vertex {vertex}, which does not exist"
+                )
+            }
+            MeshError::DegenerateCell { cell } => {
+                write!(f, "triangle {cell} repeats a vertex")
+            }
+            MeshError::ZeroArea { cell } => {
+                write!(f, "triangle {cell} has no area")
+            }
+            MeshError::BadRoughness { cell, n } => {
+                write!(f, "triangle {cell}: Manning's n must be positive (is {n})")
+            }
+            MeshError::NegativeDepth { cell } => {
+                write!(f, "triangle {cell}: initial depth cannot be negative")
+            }
+            MeshError::BadConveyance { from, to, factor } => write!(
+                f,
+                "edge conveyance {from}-{to}: the factor must lie in [0, 1] (is {factor})"
+            ),
+            MeshError::UnknownEdge { from, to } => {
+                write!(
+                    f,
+                    "edge conveyance {from}-{to}: no triangle pair shares that edge"
+                )
+            }
+            MeshError::SelfEdge { vertex } => {
+                write!(f, "edge conveyance: vertex {vertex} paired with itself")
+            }
+            MeshError::NonManifoldEdge { from, to } => write!(
+                f,
+                "edge {from}-{to} is shared by more than two triangles; the \
+                 surface folds over itself there"
+            ),
+            MeshError::BadBoundary { cell, edge } => write!(
+                f,
+                "boundary condition at triangle {cell} edge {edge}: no such \
+                 boundary edge"
+            ),
+        }
+    }
+}
+
+impl Topology {
+    /// Derive the topology and run §15.2's validation. Every defect is
+    /// returned, not just the first: an author fixing a mesh wants the
+    /// whole list.
+    pub fn build(mesh: &OverlandMesh) -> Result<Topology, Vec<MeshError>> {
+        let mut errors = Vec::new();
+        let nv = mesh.verts.len();
+        let nc = mesh.cells.len();
+        if nv < 3 || nc == 0 {
+            return Err(vec![MeshError::TooSmall {
+                verts: nv,
+                cells: nc,
+            }]);
+        }
+
+        for (ci, c) in mesh.cells.iter().enumerate() {
+            if c.v.iter().any(|&v| v as usize >= nv) {
+                let vertex = *c.v.iter().find(|&&v| v as usize >= nv).unwrap_or(&c.v[0]);
+                errors.push(MeshError::VertexOutOfRange { cell: ci, vertex });
+                continue;
+            }
+            if c.v[0] == c.v[1] || c.v[1] == c.v[2] || c.v[0] == c.v[2] {
+                errors.push(MeshError::DegenerateCell { cell: ci });
+            }
+            // Written as "not strictly positive" so NaN lands in the
+            // refusal too.
+            if c.n <= 0.0 || c.n.is_nan() {
+                errors.push(MeshError::BadRoughness { cell: ci, n: c.n });
+            }
+            if c.h0 < 0.0 {
+                errors.push(MeshError::NegativeDepth { cell: ci });
+            }
+        }
+        if !errors.is_empty() {
+            // Geometry below indexes vertices; a mesh that fails the
+            // reference checks cannot be measured.
+            return Err(errors);
+        }
+
+        let mut topo = Topology {
+            centroid: Vec::with_capacity(nc),
+            area: Vec::with_capacity(nc),
+            neighbour: vec![None; nc * 3],
+            edge_len: vec![0.0; nc * 3],
+            edge_normal: vec![[0.0, 0.0]; nc * 3],
+            edge_mid: vec![[0.0, 0.0]; nc * 3],
+            edge_z: vec![[0.0, 0.0]; nc * 3],
+            inv_dn: vec![0.0; nc * 3],
+            conveyance: vec![1.0; nc * 3],
+        };
+
+        for (ci, c) in mesh.cells.iter().enumerate() {
+            let [a, b, d] = c.v.map(|v| &mesh.verts[v as usize]);
+            let cx = (a.x + b.x + d.x) / 3.0;
+            let cy = (a.y + b.y + d.y) / 3.0;
+            let cz = (a.z + b.z + d.z) / 3.0;
+            topo.centroid.push([cx, cy, cz]);
+            let area = 0.5 * ((b.x - a.x) * (d.y - a.y) - (d.x - a.x) * (b.y - a.y)).abs();
+            if area <= 0.0 || area.is_nan() {
+                errors.push(MeshError::ZeroArea { cell: ci });
+            }
+            topo.area.push(area);
+            // Local edge e is opposite vertex e (§15.2).
+            for e in 0..3 {
+                let (p, q) = match e {
+                    0 => (b, d),
+                    1 => (d, a),
+                    _ => (a, b),
+                };
+                let slot = ci * 3 + e;
+                let (dx, dy) = (q.x - p.x, q.y - p.y);
+                let len = (dx * dx + dy * dy).sqrt();
+                topo.edge_len[slot] = len;
+                topo.edge_mid[slot] = [(p.x + q.x) / 2.0, (p.y + q.y) / 2.0];
+                topo.edge_z[slot] = if p.z <= q.z { [p.z, q.z] } else { [q.z, p.z] };
+                if len > 0.0 {
+                    // Perpendicular, oriented away from the centroid.
+                    let (mut nx, mut ny) = (dy / len, -dx / len);
+                    let mx = topo.edge_mid[slot][0] - cx;
+                    let my = topo.edge_mid[slot][1] - cy;
+                    if nx * mx + ny * my < 0.0 {
+                        nx = -nx;
+                        ny = -ny;
+                    }
+                    topo.edge_normal[slot] = [nx, ny];
+                }
+            }
+        }
+
+        // Adjacency: first cell claims an edge, the second completes the
+        // pair; a third makes the surface non-manifold.
+        use std::collections::HashMap;
+        let mut claims: HashMap<(u32, u32), (u32, u8)> = HashMap::new();
+        for (ci, c) in mesh.cells.iter().enumerate() {
+            for e in 0..3u8 {
+                let (p, q) = match e {
+                    0 => (c.v[1], c.v[2]),
+                    1 => (c.v[2], c.v[0]),
+                    _ => (c.v[0], c.v[1]),
+                };
+                let key = if p <= q { (p, q) } else { (q, p) };
+                match claims.get(&key) {
+                    None => {
+                        claims.insert(key, (ci as u32, e));
+                    }
+                    Some(&(cj, ej)) if topo.neighbour[cj as usize * 3 + ej as usize].is_none() => {
+                        topo.neighbour[ci * 3 + e as usize] = Some(cj);
+                        topo.neighbour[cj as usize * 3 + ej as usize] = Some(ci as u32);
+                    }
+                    Some(_) => {
+                        errors.push(MeshError::NonManifoldEdge {
+                            from: key.0,
+                            to: key.1,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Interior normal distances, with the §15.2 sliver floor.
+        for (ci, _) in mesh.cells.iter().enumerate() {
+            for e in 0..3 {
+                let slot = ci * 3 + e;
+                if let Some(nj) = topo.neighbour[slot] {
+                    let [nx, ny] = topo.edge_normal[slot];
+                    let dx = topo.centroid[nj as usize][0] - topo.centroid[ci][0];
+                    let dy = topo.centroid[nj as usize][1] - topo.centroid[ci][1];
+                    let dn = (dx * nx + dy * ny).abs().max(0.3 * topo.edge_len[slot]);
+                    if dn > 0.0 {
+                        topo.inv_dn[slot] = 1.0 / dn;
+                    }
+                }
+            }
+        }
+
+        // Conveyance rows resolve to edge slots, mirrored to both sides.
+        for row in &mesh.conveyance {
+            if row.from == row.to {
+                errors.push(MeshError::SelfEdge { vertex: row.from });
+                continue;
+            }
+            if !(0.0..=1.0).contains(&row.factor) {
+                errors.push(MeshError::BadConveyance {
+                    from: row.from,
+                    to: row.to,
+                    factor: row.factor,
+                });
+                continue;
+            }
+            let key = if row.from <= row.to {
+                (row.from, row.to)
+            } else {
+                (row.to, row.from)
+            };
+            match claims.get(&key) {
+                Some(&(ci, e)) => {
+                    let slot = ci as usize * 3 + e as usize;
+                    topo.conveyance[slot] = row.factor;
+                    if let Some(nj) = topo.neighbour[slot] {
+                        // The partner slot on the neighbour: find the
+                        // local edge whose neighbour is `ci`.
+                        for pe in 0..3 {
+                            if topo.neighbour[nj as usize * 3 + pe] == Some(ci) {
+                                topo.conveyance[nj as usize * 3 + pe] = row.factor;
+                            }
+                        }
+                    }
+                }
+                None => errors.push(MeshError::UnknownEdge {
+                    from: row.from,
+                    to: row.to,
+                }),
+            }
+        }
+
+        // Boundary rows must address real boundary edges.
+        for row in &mesh.boundaries {
+            let ok = (row.cell as usize) < nc
+                && row.edge < 3
+                && topo.neighbour[row.cell as usize * 3 + row.edge as usize].is_none();
+            if !ok {
+                errors.push(MeshError::BadBoundary {
+                    cell: row.cell,
+                    edge: row.edge,
+                });
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(topo)
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two right triangles closing a unit square: the smallest mesh with
+    /// an interior edge. Vertices 0..4 at the corners, diagonal 0-2.
+    fn square() -> OverlandMesh {
+        OverlandMesh {
+            verts: vec![
+                MeshVertex {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 10.0,
+                    tag: None,
+                },
+                MeshVertex {
+                    x: 1.0,
+                    y: 0.0,
+                    z: 10.2,
+                    tag: None,
+                },
+                MeshVertex {
+                    x: 1.0,
+                    y: 1.0,
+                    z: 10.4,
+                    tag: None,
+                },
+                MeshVertex {
+                    x: 0.0,
+                    y: 1.0,
+                    z: 10.6,
+                    tag: None,
+                },
+            ],
+            cells: vec![
+                MeshCell {
+                    v: [0, 1, 2],
+                    n: 0.02,
+                    h0: 0.0,
+                    tag: None,
+                },
+                MeshCell {
+                    v: [0, 2, 3],
+                    n: 0.03,
+                    h0: 0.0,
+                    tag: None,
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_square_measures_as_authored() {
+        let topo = Topology::build(&square()).expect("valid mesh");
+        assert!((topo.area[0] - 0.5).abs() < 1e-12);
+        assert!((topo.area[1] - 0.5).abs() < 1e-12);
+        // Cell 0 = (v0,v1,v2): local edge 1 joins (v2,v0) — the diagonal.
+        assert_eq!(topo.neighbour[1], Some(1));
+        // Cell 1 = (v0,v2,v3): local edge 2 joins (v0,v2) — the same edge.
+        assert_eq!(topo.neighbour[5], Some(0));
+        // Every other edge slot is boundary.
+        let boundary = topo.neighbour.iter().filter(|n| n.is_none()).count();
+        assert_eq!(boundary, 4);
+        // The diagonal's length is √2 on both slots.
+        assert!((topo.edge_len[1] - 2f64.sqrt()).abs() < 1e-12);
+        assert!((topo.edge_len[5] - 2f64.sqrt()).abs() < 1e-12);
+        // Outward normals point away from the owning centroid.
+        for ci in 0..2 {
+            for e in 0..3 {
+                let slot = ci * 3 + e;
+                let [nx, ny] = topo.edge_normal[slot];
+                let mx = topo.edge_mid[slot][0] - topo.centroid[ci][0];
+                let my = topo.edge_mid[slot][1] - topo.centroid[ci][1];
+                assert!(nx * mx + ny * my > 0.0, "cell {ci} edge {e}");
+            }
+        }
+        // Sorted endpoint beds on the diagonal: z0=10.0, z2=10.4.
+        assert_eq!(topo.edge_z[1], [10.0, 10.4]);
+    }
+
+    #[test]
+    fn conveyance_lands_on_both_sides_of_the_shared_edge() {
+        let mut mesh = square();
+        mesh.conveyance.push(ConveyanceRow {
+            from: 2,
+            to: 0,
+            factor: 0.3,
+        });
+        let topo = Topology::build(&mesh).expect("valid mesh");
+        assert_eq!(topo.conveyance[1], 0.3);
+        assert_eq!(topo.conveyance[5], 0.3);
+        // Untouched slots keep the unrestricted default.
+        assert_eq!(topo.conveyance[0], 1.0);
+    }
+
+    /// Reference-level defects are all named together, and they gate the
+    /// derived checks: rows over an unmeasurable mesh are not judged.
+    #[test]
+    fn reference_defects_are_named_together_and_gate_the_rest() {
+        let mut mesh = square();
+        mesh.cells[0].n = 0.0;
+        mesh.cells[1].v = [0, 2, 2];
+        mesh.conveyance.push(ConveyanceRow {
+            from: 1,
+            to: 1,
+            factor: 0.5,
+        });
+        let errors = Topology::build(&mesh).expect_err("defective mesh");
+        assert!(errors.contains(&MeshError::BadRoughness { cell: 0, n: 0.0 }));
+        assert!(errors.contains(&MeshError::DegenerateCell { cell: 1 }));
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, MeshError::SelfEdge { .. })),
+            "rows are not judged over an unmeasurable mesh"
+        );
+    }
+
+    /// Row-level defects over a sound mesh are all named together.
+    #[test]
+    fn row_defects_are_named_over_a_sound_mesh() {
+        let mut mesh = square();
+        mesh.conveyance.push(ConveyanceRow {
+            from: 1,
+            to: 3,
+            factor: 0.5,
+        });
+        mesh.conveyance.push(ConveyanceRow {
+            from: 1,
+            to: 1,
+            factor: 0.5,
+        });
+        mesh.conveyance.push(ConveyanceRow {
+            from: 2,
+            to: 0,
+            factor: 1.5,
+        });
+        let errors = Topology::build(&mesh).expect_err("bad rows");
+        assert!(errors.contains(&MeshError::UnknownEdge { from: 1, to: 3 }));
+        assert!(errors.contains(&MeshError::SelfEdge { vertex: 1 }));
+        assert!(errors.contains(&MeshError::BadConveyance {
+            from: 2,
+            to: 0,
+            factor: 1.5
+        }));
+    }
+
+    #[test]
+    fn boundary_rows_must_address_boundary_edges() {
+        let mut mesh = square();
+        // The diagonal is interior: cell 0 edge 1.
+        mesh.boundaries.push(BoundaryRow {
+            cell: 0,
+            edge: 1,
+            condition: BoundaryCondition::Wall,
+            group: None,
+        });
+        let errors = Topology::build(&mesh).expect_err("interior edge");
+        assert!(errors.contains(&MeshError::BadBoundary { cell: 0, edge: 1 }));
+        // A real boundary edge is accepted.
+        let mut mesh = square();
+        mesh.boundaries.push(BoundaryRow {
+            cell: 0,
+            edge: 2,
+            condition: BoundaryCondition::NormalFlow { slope: 0.01 },
+            group: None,
+        });
+        assert!(Topology::build(&mesh).is_ok());
+    }
+
+    #[test]
+    fn a_folded_surface_is_refused() {
+        let mut mesh = square();
+        // A third cell claiming the diagonal.
+        mesh.verts.push(MeshVertex {
+            x: 0.5,
+            y: -0.5,
+            z: 11.0,
+            tag: None,
+        });
+        mesh.cells.push(MeshCell {
+            v: [0, 2, 4],
+            n: 0.02,
+            h0: 0.0,
+            tag: None,
+        });
+        let errors = Topology::build(&mesh).expect_err("non-manifold");
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, MeshError::NonManifoldEdge { .. })));
+    }
+}

--- a/crates/engine-uds/src/overland/mod.rs
+++ b/crates/engine-uds/src/overland/mod.rs
@@ -40,6 +40,34 @@ pub struct OverlandMesh {
     pub mesh_file: Option<String>,
 }
 
+impl OverlandMesh {
+    /// Resolve a §14.15 address against the vertices: an index where
+    /// numeric and in range, else a tag.
+    pub fn resolve_vertex(&self, address: &str) -> Option<u32> {
+        resolve(address, self.verts.len(), |i| self.verts[i].tag.as_deref())
+    }
+
+    /// Resolve a §14.15 address against the cells, the same rule.
+    pub fn resolve_cell(&self, address: &str) -> Option<u32> {
+        resolve(address, self.cells.len(), |i| self.cells[i].tag.as_deref())
+    }
+}
+
+fn resolve<'a>(
+    address: &str,
+    count: usize,
+    tag_of: impl Fn(usize) -> Option<&'a str>,
+) -> Option<u32> {
+    if let Ok(i) = address.parse::<u32>() {
+        if (i as usize) < count {
+            return Some(i);
+        }
+    }
+    (0..count)
+        .position(|i| tag_of(i) == Some(address))
+        .map(|i| i as u32)
+}
+
 /// One §14.15 initial-velocity row.
 #[derive(Debug, Clone, PartialEq)]
 pub struct InitVelocityRow {
@@ -76,8 +104,11 @@ pub struct MeshCell {
 /// vertex, with its discharge coefficient and exchange area.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CouplingRow {
-    /// Mesh vertex or cell index (per the owning list).
-    pub mesh_index: u32,
+    /// The mesh vertex or cell as authored: an index where numeric and
+    /// in range, else a tag (§14.15). Resolution is derivation — an
+    /// external mesh file may author the vertices a row in the model
+    /// addresses — so it happens at [`Topology::build`], never at parse.
+    pub address: String,
     /// The coupled network vertex, as the model names it; resolved at
     /// build against §2.6 identifiers.
     pub node: String,
@@ -261,6 +292,10 @@ pub enum MeshError {
     /// A boundary row addresses a cell or edge that does not exist, or
     /// an interior edge.
     BadBoundary { cell: u32, edge: u8 },
+    /// A coupling row's address matches no index and no tag.
+    UnknownAddress { address: String },
+    /// An initial-velocity row names a cell that does not exist.
+    BadInitVelocity { cell: u32 },
 }
 
 impl std::fmt::Display for MeshError {
@@ -312,6 +347,16 @@ impl std::fmt::Display for MeshError {
                 "boundary condition at triangle {cell} edge {edge}: no such \
                  boundary edge"
             ),
+            MeshError::UnknownAddress { address } => write!(
+                f,
+                "coupling address {address:?} matches no index and no tag"
+            ),
+            MeshError::BadInitVelocity { cell } => {
+                write!(
+                    f,
+                    "initial velocity names triangle {cell}, which does not exist"
+                )
+            }
         }
     }
 }
@@ -488,6 +533,29 @@ impl Topology {
                     from: row.from,
                     to: row.to,
                 }),
+            }
+        }
+
+        // Coupling addresses resolve against the full mesh; §14.15's
+        // last-wins rule for vertex rows applies at resolution, so two
+        // spellings of one vertex are one coupling.
+        for row in &mesh.vertex_couplings {
+            if mesh.resolve_vertex(&row.address).is_none() {
+                errors.push(MeshError::UnknownAddress {
+                    address: row.address.clone(),
+                });
+            }
+        }
+        for row in &mesh.cell_couplings {
+            if mesh.resolve_cell(&row.address).is_none() {
+                errors.push(MeshError::UnknownAddress {
+                    address: row.address.clone(),
+                });
+            }
+        }
+        for row in &mesh.init_velocity {
+            if row.cell as usize >= nc {
+                errors.push(MeshError::BadInitVelocity { cell: row.cell });
             }
         }
 

--- a/crates/engine-uds/src/overland/mod.rs
+++ b/crates/engine-uds/src/overland/mod.rs
@@ -6,7 +6,9 @@
 //! carrying a mesh receives.
 
 pub mod closure;
+pub mod coupling;
 pub mod marcher;
+pub mod meteorology;
 
 /// The authored overland surface (§15.2, §14.15), in SI after import.
 ///

--- a/crates/engine-uds/src/overland/mod.rs
+++ b/crates/engine-uds/src/overland/mod.rs
@@ -5,6 +5,9 @@
 //! these in later phases; until they land, §1.8 governs what a model
 //! carrying a mesh receives.
 
+pub mod closure;
+pub mod marcher;
+
 /// The authored overland surface (§15.2, §14.15), in SI after import.
 ///
 /// Everything here is what the file said, converted and index-resolved,

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -548,7 +548,9 @@ implemented reference solutions: lake at rest over immersed and emerged
 bumps (exact to round-off — the well-balancing property, which the
 deadband and face-gating exist to protect); subcritical flow over a bump
 (≲ 1%, the residual being the omitted velocity-head dip); MacDonald
-subcritical profile (≲ 2%). A frictionless case posed between a
+subcritical profile (≈ 2%, likewise the omitted velocity-head term,
+integrated along the channel; the predecessor's marcher measures 2.0%
+on the same case). A frictionless case posed between a
 specified-flow inlet and a specified-stage outlet holds an undamped
 standing wave — both laws reflect, and the scheme adds no dissipation
 of its own — so steady analytic cases are graded on the **time-mean**

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -276,7 +276,16 @@ at the *finer* of its two cells' cadences, and the positivity share of
 cannot be overdrawn by a fine face. Boundary-condition and coupling cells
 are pinned to tier 0. Tiers and the active set rebuild every fourth macro
 cycle; between rebuilds the base step may only tighten (a frozen step has
-been observed to let a seiche grow at $\alpha = 0.7$). A window tail too
+been observed to let a seiche grow at $\alpha = 0.7$). Re-tiering
+invalidates the positivity bookkeeping of any in-flight accumulator (a
+face's take count restarts against an exporter volume that has not yet
+absorbed the pending takes, and the doubled grant has been measured to
+overdraw cells into the positivity floor, leaking volume), so every
+pending accumulator side is gathered into its cell, and the cell's
+closure re-evaluated, immediately before tiers are reassigned — at every
+rebuild and before a tail collapse. A face walled by deactivation
+surrenders its discharge at the rebuild: stale momentum must not survive
+re-activation. A window tail too
 short for a full macro cycle collapses every cell to tier 0 and lands
 exactly on the target time: **an advance always reaches its target** —
 there is no rejection or retry in this subsystem, and §15.4.6 records why
@@ -293,6 +302,17 @@ halo of the active set is kept active so an advancing front always has a
 receiving cell, and a face conveys only when **both** its cells are
 active (one-sided conveyance has been measured to lose basin volume).
 Cells with coupling points or non-wall boundary edges are always active.
+
+**The published picture.** An advance returns with every cell at the
+target time, but a prognostic face discharge was last clamped against
+the surface it saw at its own firing, and cell firings since have moved
+that surface: a draining front would otherwise expose a super-Froude
+discharge inconsistent with the published depths. The observable face
+discharge is therefore re-limited on reading: the face flow depth is
+re-evaluated from the published surfaces (§15.3), a face at or below
+the drying depth reads zero, and the Froude cap of §15.4.2 is
+re-applied. The prognostic value is untouched; the re-limit is a
+reading, not an integration step.
 
 #### 15.4.5 Concurrency
 
@@ -515,7 +535,12 @@ implemented reference solutions: lake at rest over immersed and emerged
 bumps (exact to round-off — the well-balancing property, which the
 deadband and face-gating exist to protect); subcritical flow over a bump
 (≲ 1%, the residual being the omitted velocity-head dip); MacDonald
-subcritical profile (≲ 2%). Transcritical, dam-break, and oscillating
+subcritical profile (≲ 2%). A frictionless case posed between a
+specified-flow inlet and a specified-stage outlet holds an undamped
+standing wave — both laws reflect, and the scheme adds no dissipation
+of its own — so steady analytic cases are graded on the **time-mean**
+field over whole periods of the settled oscillation, which is the
+steady solution the oscillation rides on. Transcritical, dam-break, and oscillating
 (Thacker) cases are graded against recorded baselines rather than
 analytic solutions while the convective term is optional, and the
 supercritical MacDonald profile is an **expected failure**, recorded as

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -248,7 +248,10 @@ $$\mathbf{q}_c = \frac{1}{A} \sum_e s_e\, q_e\, \xi_e\,
 (\mathbf{m}_e - \mathbf{c}),$$
 
 $s_e$ the cell's sign for the edge's orientation and $\mathbf{m}_e$ the
-edge midpoint. Each cell writes only its own state and clears only its
+edge midpoint. The offset $\mathbf{m}_e - \mathbf{c}$ is the formula:
+substituting the face normal — plausible on a near-orthogonal mesh —
+was measured to destabilise the march outright, the θ-blend feeding on
+its own mis-reconstruction until the basin stood in metre-scale waves. Each cell writes only its own state and clears only its
 own accumulator sides: the phase is order-independent and
 byte-reproducible at any width.
 
@@ -337,12 +340,20 @@ condition addresses its (cell, edge) slot. Five types:
 | `SPECIFIED_STAGE` | the §15.4.2 momentum law against a ghost cell held at the authored (or time-series) stage, slope arm $d_n = 2A/(3\xi)$, the cell's own $n^2$, prognostic discharge |
 
 $h$ is the cell-mean depth under `MEAN` reconstruction and the wetted-edge
-depth under `VFR_FACE`. All boundary applications clamp in volume space —
-a cell cannot be driven negative, and a stage boundary cannot overshoot
-its equilibrium volume within one substep — and the flux booked to the
-§15.8 ledger is re-derived from the volume actually applied, so booking
-and application agree exactly. Boundary edges evaluate at tier-0 cadence,
-sequentially.
+depth under `VFR_FACE`. All boundary applications clamp in volume
+space — a cell cannot be driven negative, and one substep of a stage
+boundary moves its cell at most **to** the prescribed stage, from
+either side — and the flux booked to the §15.8 ledger is re-derived
+from the volume actually applied, so booking and application agree
+exactly. The prognostic discharge is likewise re-derived from the
+applied flux: a clamped exchange that kept its unclamped momentum
+would wind up and drive the basin as an oscillator instead of settling
+it. A cell fed through a boundary edge also carries that edge's
+discharge in its §15.4.3 velocity reconstruction, in the same
+outward-flux convention — reconstructed from interior faces alone, a
+boundary-fed cell's θ-blend drags every interior exchange by the
+reconstruction's missing share. Boundary edges evaluate at tier-0
+cadence, sequentially.
 
 > **CORRESPONDENCE:** the predecessor's earlier diffusive stage-boundary
 > law left every boundary-driven steady case one velocity head above the

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -579,10 +579,11 @@ Typed, per §1.8 — each is a named absence, not an approximation:
   §14.9 reporting instants — chosen over the predecessor's CF/UGRID
   HDF5 because a native-library dependency conflicts with the browser
   build's constraints (§1.4).
-- **Checkpoint carriage.** §12.3 checkpoints do not yet carry overland
-  state; a run with a mesh refuses checkpointing until they do (format
-  version bump when it lands). The predecessor's hotstart files have the
-  same gap.
+- **Checkpoint carriage: resolved.** §12.3 carries the overland state
+  — mesh runs checkpoint and resume bit-identically, behind their own
+  mesh fingerprint. The one deviation is recorded there: the §14.16
+  sidecar of a resumed run begins at the resume instant. The
+  predecessor's hotstart files carry no 2D state at all.
 - **Sub-rim street drainage.** Junction exchange opens only at the
   rim; a surface film over a node whose water stands below ground does
   not drain into it.

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -572,13 +572,11 @@ to round-trip precision.
 
 Typed, per §1.8 — each is a named absence, not an approximation:
 
-- **Time-series results for the mesh.** The predecessor writes
-  CF/UGRID HDF5. This engine's overland results surface — format,
-  cadence, and its relation to §14.9's results stream — is a recorded
-  gap, to be specified before the output phase implements anything. A
-  heavyweight native-library dependency conflicts with the browser
-  build's constraints (§1.4), and the resolution is a specification
-  decision, not an implementation one.
+- **Time-series results for the mesh: resolved.** §14.16 specifies the
+  sidecar results stream — this engine's own framed layout at the
+  §14.9 reporting instants — chosen over the predecessor's CF/UGRID
+  HDF5 because a native-library dependency conflicts with the browser
+  build's constraints (§1.4).
 - **Checkpoint carriage.** §12.3 checkpoints do not yet carry overland
   state; a run with a mesh refuses checkpointing until they do (format
   version bump when it lands). The predecessor's hotstart files have the
@@ -589,10 +587,9 @@ Typed, per §1.8 — each is a named absence, not an approximation:
 - **Runoff-to-mesh.** Parcel runoff routes to nodes only.
 - **Mesh infiltration**, **overland constituent transport**, **mesh
   adaptivity**: absent here as in the predecessor.
-- **Report additions.** The §14.9 run summary gains the overland
-  continuity block and solver statistics when §15 is served; their
-  layout is specified with the §15.8 accounting's implementation, not
-  before.
+- **Report additions: resolved.** §14.9 specifies the overland flow
+  continuity balance, the overland time-step summary, and the flow
+  routing balance's §15.8 named pair.
 - **Device compute.** The marcher's kernels are specified as pure
   per-element maps over flat state, which is deliberately the shape a
   GPU backend could lift without restructuring. None is planned: the

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -1,0 +1,559 @@
+# Urban Drainage — Overland Flow Specification
+
+This document holds §15 of the urban drainage specification: two-dimensional
+overland flow on a surface mesh, and its couplings to the §6 network, the
+§3 meteorology, and the §11 conservation ledger.
+
+---
+
+## 15. Overland Flow
+
+### 15.1 Scope and Stance
+
+The engine simulates free-surface flow over a two-dimensional ground
+surface: rainfall and network surcharge spreading across terrain, ponding
+in depressions, conveying along streets and floodplains, and returning to
+the network or leaving the domain across its boundary. The governing
+physics is the two-dimensional shallow-water system in its **local-inertial
+approximation**: continuity is kept exactly, and the momentum equation
+keeps its local acceleration, pressure-gradient, and friction terms —
+the retained inertia is what names the scheme — while the convective
+acceleration is omitted by default. The approximation is standard for
+flood-spreading problems (Bates, Horritt & Fewtrell 2010; de Almeida &
+Bates 2013), where depths are shallow, slopes are mild, and friction
+dominates momentum; it is *not* a model of momentum-dominated flow, and
+§15.4.6 states the consequences plainly.
+
+**Correspondence.** The predecessor for this section is the community
+continuation of SWMM — `openswmm.engine`, whose 6.x line grows
+two-dimensional simulation on the SWMM input format. Its 2D subsystem is
+pre-release: this specification is written against its explicit
+local-inertial marcher (the sole 2D integrator since its implicit
+integrators were retired, 2026-07-29), and correspondence notes cite that
+implementation. The stance follows §14.1: the *input format* is adopted
+absolutely, section for section and default for default, so a model
+authored for the predecessor means the same thing here; the *internal
+laws* are specified on their own terms, and every difference a user could
+observe in results is recorded where it arises. Because the predecessor
+is an alpha, §15.10 records the format-stability boundary: the mesh,
+boundary-condition, and coupling-map sections are treated as stable; the
+options vocabulary is expected to churn, and unknown or retired option
+keys warn and are ignored rather than refusing the file.
+
+**Placement in the cascade.** Overland flow joins §1.1's per-step
+influence cascade as a peer of the network: within a routing step the
+network solves with the overland surface's state frozen, then the surface
+advances with the network's state frozen, and the volumes they exchange
+are booked exactly once (§15.6). The influence graph within a step
+remains loop-free.
+
+**Units.** All overland quantities are SI internally, as everywhere in
+this engine: metres, square metres, cubic metres per second, and
+$g = 9.80665\ \text{m/s}^2$. Input-side unit handling is §14.15's.
+
+> **CORRESPONDENCE:** the predecessor's 1D engine computes internally in
+> feet while its 2D subsystem computes in SI, so every coupling quantity
+> crosses a hard-coded ft↔m boundary (a historical defect had tied those
+> factors to the project's flow units, corrupting SI-project coupling).
+> This engine is SI throughout, so no such boundary exists to get wrong.
+
+### 15.2 The Mesh
+
+The surface is an **unstructured triangular mesh**: vertices carry a
+position and ground elevation $(x, y, z)$; cells are triangles over three
+vertex indices, each carrying a Manning roughness $n > 0$, an optional
+initial depth $h_0 \geq 0$ (default 0, dry), and an optional identifying
+tag. The mesh is planimetric: areas and lengths are measured in plan, and
+no terrain steeper than its planimetric projection is represented.
+
+**Local edge convention.** Cell edge $e \in \{0,1,2\}$ is the edge
+*opposite* local vertex $e$: for a cell $(v_0, v_1, v_2)$, edge 0 joins
+$(v_1, v_2)$, edge 1 joins $(v_2, v_0)$, edge 2 joins $(v_0, v_1)$.
+
+**Topology.** Adjacency is discovered, not declared: two cells sharing a
+vertex pair are neighbours across that edge; an edge no second cell
+claims is a **boundary edge**, and the set of boundary edges is the whole
+of the domain-boundary declaration. Boundary conditions (§15.5) attach to
+specific (cell, edge) slots; every boundary edge not so addressed is a
+wall.
+
+**Derived geometry.** Cell centroid $\mathbf{c} = $ the vertex mean (in
+$x$, $y$, and $z$; the elevation mean $\bar z$ is the cell's bed datum for
+the flat closure); cell area $A = \tfrac12 \lvert (\mathbf{v}_1 -
+\mathbf{v}_0) \times (\mathbf{v}_2 - \mathbf{v}_0) \rvert$ (orientation
+insensitive; winding order is not required of the input). Each edge
+carries its planimetric length $\xi$, midpoint, outward unit normal
+$\hat{\mathbf{n}}$ (perpendicular to the edge, oriented away from the
+centroid), a face bed $z_f = \max(\bar z_L, \bar z_R)$ over the two
+incident cells, the sorted endpoint beds $z_{lo} \leq z_{hi}$, and the
+inverse normal distance
+
+$$\frac{1}{d_n} = \frac{1}{\max\!\big(\lvert(\mathbf{c}_R -
+\mathbf{c}_L)\cdot\hat{\mathbf{n}}\rvert,\ 0.3\,\xi\big)},$$
+
+the floor guarding slivers whose centroids nearly share the edge line.
+
+**Edge conveyance.** Each interior edge carries a conveyance factor
+$\psi \in \lbrack 0, 1\rbrack$ (default 1), a sub-grid representation of walls, fences
+and berms: it multiplies the edge's flux (§15.4.2). The factor is a
+property of the undirected edge — both incident cells see the same
+$\psi$ — so antisymmetry of the flux, and with it conservation, is
+unaffected.
+
+> **CORRESPONDENCE:** the predecessor parses, stores, and documents this
+> factor as complete, but its current marcher never reads it — the only
+> consumer was its retired implicit solver, so the factor is inert
+> there. This engine applies it as documented. A model relying on
+> conveyance barriers computes differently here, and correctly.
+
+**Validation.** A mesh is refused (typed, per §1.8) unless: at least
+three vertices and one cell; all vertex indices in range; no repeated
+vertex within a cell; every cell area strictly positive; every Manning
+$n$ strictly positive; every initial depth non-negative; every $\psi$
+within $\lbrack 0, 1\rbrack$.
+
+### 15.3 Stage–Storage Closures
+
+The **conserved variable is the cell's water volume** $V$ (m³). Free
+surface elevation $\eta$ and mean depth $\bar h = V / A$ are derived from
+$V$ through a closure, re-evaluated whenever $V$ changes, and never
+integrated themselves.
+
+**FLAT** (default): the cell floor is flat at the centroid bed,
+
+$$\eta = \bar z + \bar h.$$
+
+**VFR** (volume–free-surface relation): the exact stage–storage relation
+of a planar bed through the cell's three vertex elevations (Begnudelli &
+Sanders 2006, 2007). With sorted elevations $z_1 \leq z_2 \leq z_3$ and
+$\bar z = (z_1{+}z_2{+}z_3)/3$:
+
+$$\bar h(\eta) = \begin{cases}
+\dfrac{(\eta - z_1)^3}{3\,(z_2 - z_1)(z_3 - z_1)} & z_1 < \eta \leq z_2\\
+(\eta - \bar z) + \dfrac{(z_3 - \eta)^3}{3\,(z_3 - z_1)(z_3 - z_2)} & z_2 < \eta \leq z_3\\
+\eta - \bar z & \eta \geq z_3
+\end{cases}$$
+
+with the **wet-area fraction** $\mathrm{d}\bar h/\mathrm{d}\eta$ equal to
+$(\eta - z_1)^2 / \big((z_2 - z_1)(z_3 - z_1)\big)$ on the lower branch and
+$1 - (z_3 - \eta)^2 / \big((z_3 - z_1)(z_3 - z_2)\big)$ on the middle one.
+A fully wet cell reduces exactly to the flat closure. The inverse
+$\eta(\bar h)$ is closed-form (a cube root) on the lower branch and a
+safeguarded bracketed iteration on the middle one, and the pair are exact
+inverses of each other so state may round-trip without drift. The
+relation is **regularised** by a wet-fraction floor $\varepsilon$
+(`VFR_MIN_WET_FRAC`, default 0.01): below the stage where the wet
+fraction reaches $\varepsilon$ the relation continues as its tangent with
+slope $\varepsilon$, keeping the closure $C^1$ and monotone as a cell
+dries. A near-flat cell (relief below $10^{-9}$ m) uses the flat closure
+outright.
+
+The flat closure overstates a partially wet cell's surface by up to two
+thirds of the cell's relief — water appears to climb the cell's high
+corner — and with it the well-balancing of §15.4.6 at shorelines is
+approximate rather than exact. VFR is the physically correct closure and
+is deliberately *not* the default: it steepens the shoreline dynamics and
+costs a multiple of the substeps, and the default follows the
+predecessor so that results and costs correspond. The choice is the
+model's, per §14.15.
+
+**Face depth.** The depth that conveys across an edge, under
+`FACE_RECONSTRUCTION`:
+
+- **MEAN** (default): $h_f = \max(\eta_L, \eta_R) - z_f$ — the higher
+  water surface over the higher cell bed.
+- **VFR_FACE**: the wetted-edge mean depth of $\eta = \max(\eta_L,\eta_R)$
+  over the edge's own endpoint beds (Begnudelli & Sanders 2007, eq. 14):
+  $0$ for $\eta \leq z_{lo}$; $(\eta - z_{lo})^2 / \big(2(z_{hi} -
+  z_{lo})\big)$ for $z_{lo} < \eta \leq z_{hi}$; $\eta - (z_{lo} +
+  z_{hi})/2$ above — $C^1$ at both joins.
+
+### 15.4 The Marcher
+
+Overland state advances by an explicit two-phase march: a **∥ face
+phase** updates every edge's discharge from the published cell surfaces,
+then a **∥ cell phase** applies every cell's accumulated fluxes and
+sources and republishes its surface. The phases alternate under the
+time-step control of §15.4.4.
+
+#### 15.4.1 State
+
+Each interior edge carries one prognostic unit-width discharge $q$
+(m²/s), oriented from the lower-indexed to the higher-indexed incident
+cell, and two pending-mass accumulators (m³), one per side. Each cell
+carries its volume $V$, its derived $\eta$ and $\bar h$, a reconstructed
+velocity proxy $\mathbf{q}_c$ (§15.4.3), and its source rates. Boundary
+edges carry their own prognostic discharge (§15.5).
+
+#### 15.4.2 ∥ Face phase
+
+Every due edge computes its new discharge from the last published cell
+surfaces. The face depth $h_f$ comes from §15.3; if $h_f \leq h_{dry}$
+(`DRY_DEPTH`, default 0.001 m) the edge is a wall this substep: $q
+\leftarrow 0$, nothing books. Otherwise, with surface difference $\Delta\eta
+= \eta_R - \eta_L$ (a deadband $\lvert\Delta\eta\rvert < 10^{-12}$ m is
+taken as zero, so closure round-off cannot masquerade as slope), slope
+$S_f = \Delta\eta / d_n$, and the θ-blended semi-implicit update (de
+Almeida & Bates 2013; $\theta = 1$ recovers Bates 2010):
+
+$$\hat q = \theta\,q + (1-\theta)\ \tfrac12(\mathbf{q}_{c,L} +
+\mathbf{q}_{c,R})\cdot\hat{\mathbf{n}}$$
+
+$$q^{+} = \frac{\hat q - \Delta t\,\big(g\,h_f\,S_f + a\big)}
+{1 + g\,\Delta t\, n_f^2\, \lvert\mathbf{q}\rvert_{\max}\ /\ h_f^{7/3}}$$
+
+where $n_f^2 = \big(\tfrac12(n_L + n_R)\big)^2$, and
+$\lvert\mathbf{q}\rvert_{\max} = \max\big(\lvert q \rvert,
+\lvert\tfrac12(\mathbf{q}_{c,L}+\mathbf{q}_{c,R})\rvert\big)$ is the
+**flow-vector magnitude**, floored at the face's own $\lvert q\rvert$.
+The friction denominator must use the vector magnitude: using only the
+face-normal component under-damps the transverse component and corrugates
+steady sheet flow. $a$ is the optional convective term (§15.4.6),
+zero by default. The result is clamped by the **Froude cap**,
+
+$$\lvert q^{+} \rvert \leq \mathrm{Fr}_{\max}\, h_f \sqrt{g\,h_f},$$
+
+$\mathrm{Fr}_{\max}$ default 1.5 — a numerical device, not physics
+(§15.4.6) — and by **positivity**: the exporting cell grants each of its
+three edges at most a $\beta/3$ share of its volume per cell cycle
+($\beta = 0.8$), divided by the number of times the face fires per cell
+cycle at a tier interface (§15.4.4); a discharge that would overdraw the
+share is scaled down. The edge conveyance $\psi$ multiplies the final
+flux.
+
+The edge then books the mass it moved, $\Delta M = \psi\, q^{+} \xi\,
+\Delta t_f$, into its two side accumulators with opposite signs. Each
+edge is the **single writer** of its own discharge and its own two
+accumulators, so the phase is order-independent and byte-reproducible
+under any §6.4 width; both sides book the *same* floating-point product,
+so interior conservation is exact by construction, tier interfaces
+included.
+
+#### 15.4.3 ∥ Cell phase
+
+Every due cell drains its own side of each incident edge's accumulator
+(in fixed ascending edge order), applies its sources, and clamps at dry:
+
+$$V^{+} = \max\Big(0,\ V + \textstyle\sum_e \Delta M_e + \Delta t_c\,
+\big(r + c - E\big)\,A\Big)$$
+
+where $r$ is the cell's rainfall rate (§15.7), $c$ its coupling rate
+(§15.6), and $E$ its evaporation demand under a $C^1$ ramp
+$t^2(3-2t)$, $t = \bar h / h_{dry}$, so evaporation shuts off smoothly as
+the cell dries rather than chattering at the threshold. The closure then
+republishes $(\eta, \bar h)$, and the cell's velocity proxy is
+reconstructed by the Perot formula over its own edges, in fixed order:
+
+$$\mathbf{q}_c = \frac{1}{A} \sum_e s_e\, q_e\, \xi_e\,
+(\mathbf{m}_e - \mathbf{c}),$$
+
+$s_e$ the cell's sign for the edge's orientation and $\mathbf{m}_e$ the
+edge midpoint. Each cell writes only its own state and clears only its
+own accumulator sides: the phase is order-independent and
+byte-reproducible at any width.
+
+#### 15.4.4 Time stepping
+
+The stable step of cell $i$ is the CFL bound of the discrete operator,
+
+$$\Delta t_i = \alpha\ \frac{L_i}{\sqrt{g \bar h_i} +
+\lvert \mathbf{u}_i \rvert}, \qquad
+L_i = \sqrt{\frac{2 A_i}{\sum_e \xi_e / d_{n,e}}},$$
+
+$\alpha$ = `CFL_NUMBER` (default 0.7, with $\alpha = 1$ the linear
+stability limit of the scheme on this mesh metric), $\lvert\mathbf{u}\rvert
+= \lvert\mathbf{q}_c\rvert / \bar h$, capped by `MAX_TIMESTEP` (default
+10 s). The base step $\Delta t_0$ is the minimum over active cells.
+
+**Local time stepping.** Cells are assigned to power-of-two tiers, tier
+$k$ firing every $2^k$ base substeps with $\Delta t = 2^k \Delta t_0$, up
+to `LTS_TIERS` tiers (default 4; 1 disables the mechanism). A face fires
+at the *finer* of its two cells' cadences, and the positivity share of
+§15.4.2 divides by the face's firings per cell cycle, so a coarse cell
+cannot be overdrawn by a fine face. Boundary-condition and coupling cells
+are pinned to tier 0. Tiers and the active set rebuild every fourth macro
+cycle; between rebuilds the base step may only tighten (a frozen step has
+been observed to let a seiche grow at $\alpha = 0.7$). A window tail too
+short for a full macro cycle collapses every cell to tier 0 and lands
+exactly on the target time: **an advance always reaches its target** —
+there is no rejection or retry in this subsystem, and §15.4.6 records why
+none is needed.
+
+**Wetting and drying.** A cell participates in the march only while
+**active**. Activation carries hysteresis about `H_MOVE` (default
+0.003 m) with band $\min(1\ \text{mm}, h_{move}/2)$: a cell activates
+above $h_{move} + \text{band}$ and deactivates below $h_{move} -
+\text{band}$. Rain alone never activates a cell: inactive cells
+integrate their sources lazily as pure storage between rebuilds, and
+enter the march only when their depth crosses the threshold. A one-ring
+halo of the active set is kept active so an advancing front always has a
+receiving cell, and a face conveys only when **both** its cells are
+active (one-sided conveyance has been measured to lose basin volume).
+Cells with coupling points or non-wall boundary edges are always active.
+
+#### 15.4.5 Concurrency
+
+The ∥ marks above are the §1.7 grant: the face phase and the cell phase
+may run across the §6.4 worker width, and their writes are per-edge and
+per-cell disjoint with fixed-order gathers, so results are
+byte-identical at every width — the same contract §6.4 carries.
+Boundary-edge evaluation (§15.5) and network exchange (§15.6) are
+specified **sequential**, in file order; they are small, and their shared
+ledgers make order part of the result.
+
+#### 15.4.6 Validity, stated plainly
+
+The scheme omits convective acceleration by default. Consequences: a
+transcritical control has no drawdown (the frictionless steady state of
+the truncated momentum equation is a *flat* surface); dam-break fronts
+are first-order; results pinned at the Froude cap are the cap's, not
+physics. An optional Stelling–Duinmeijer convective term (`ADVECTION`,
+default off) adds the upwind momentum flux difference $a = (u_R \hat
+q_R - u_L \hat q_L)/d_n$ between wet cells, with $u_c =
+(\mathbf{q}_c\cdot\hat{\mathbf{n}})/\bar h_c$ and the upwind flux taken
+from the donor cell; it improves transcritical cases and remains
+off-by-default until its validation grades are settled (§15.9). Momentum
+stored on a face is discarded when the face gates dry — a known,
+accepted dissipation at wetting fronts. A model whose answer depends on
+momentum-dominated hydraulics is outside this section's validity, and
+the specification says so rather than approximating silently.
+
+No error control governs this subsystem — the explicit CFL bound is the
+accuracy control, unlike §6.5's error-steered stepping — because the
+scheme is everywhere first-order in time at a step the stability bound
+already holds near the accuracy scale.
+
+### 15.5 Domain Boundaries
+
+Every boundary edge is a **wall** (zero flux) unless a boundary
+condition addresses its (cell, edge) slot. Five types:
+
+| Type | Law |
+|---|---|
+| `WALL` | $F = 0$ |
+| `NORMAL_FLOW` | Manning outfall at the authored bed slope $S$: $F = -\dfrac{h^{5/3}\sqrt{S}}{n}\,\xi$ |
+| `SPECIFIED_FLOW` | $F = -q_{bc}\,\xi$, $q_{bc}$ the authored (or time-series) per-metre discharge |
+| `RATING_CURVE` | as `SPECIFIED_FLOW` with $q_{bc}$ read from a curve of stage above the edge bed |
+| `SPECIFIED_STAGE` | the §15.4.2 momentum law against a ghost cell held at the authored (or time-series) stage, slope arm $d_n = 2A/(3\xi)$, the cell's own $n^2$, prognostic discharge |
+
+$h$ is the cell-mean depth under `MEAN` reconstruction and the wetted-edge
+depth under `VFR_FACE`. All boundary applications clamp in volume space —
+a cell cannot be driven negative, and a stage boundary cannot overshoot
+its equilibrium volume within one substep — and the flux booked to the
+§15.8 ledger is re-derived from the volume actually applied, so booking
+and application agree exactly. Boundary edges evaluate at tier-0 cadence,
+sequentially.
+
+> **CORRESPONDENCE:** the predecessor's earlier diffusive stage-boundary
+> law left every boundary-driven steady case one velocity head above the
+> prescribed stage; its current inertial ghost-cell law, adopted here,
+> removed that offset.
+
+### 15.6 Network Coupling
+
+The overland surface and the §6 network exchange at **coupling points**:
+authored mappings from a mesh vertex or cell to a network node (§14.15).
+Nothing couples implicitly — an unmapped node never exchanges. A vertex
+mapping conveys through the vertex's incident-cell stencil; for junction
+exchange the stencil collapses to its lowest-bed cell (where water
+actually pools), while volume scattering spreads across the stencil
+weighted by the surface slope toward each cell (downhill for arriving
+water, uphill for draining), falling back to geometric weights on a flat
+surface.
+
+**Junction exchange** is one orifice law for both directions. With
+$\Delta h = \eta_{2D} - h_{1D}$ (the overland surface against the node's
+hydraulic grade, both in metres of the shared datum):
+
+$$Q = C_d\, A_{\!e}\ \mathrm{sign}(\Delta h)\, \sqrt{2g}\
+\varphi(\lvert \Delta h \rvert) \cdot G_{rim} \cdot R_{wet}$$
+
+- $\varphi(x) = \sqrt{x}$ for $x \geq \varepsilon_h$ ($\varepsilon_h$ =
+  0.02 m); below, the $C^1$ quadratic
+  $\varphi(x) = \tfrac{3}{2\sqrt{\varepsilon_h}}\,x -
+  \tfrac{1}{2\varepsilon_h^{3/2}}\,x^2$ matching value and slope at
+  $\varepsilon_h$ — the infinite slope of the bare square root at
+  $\Delta h = 0$ is exactly the stiffness that makes near-equal heads
+  oscillate, and the regularisation removes it.
+- $G_{rim}$: a $C^1$ smoothstep opening over the 50 mm above the node's
+  **rim** — the ground elevation, invert plus the node's full depth —
+  evaluated at $\max(\eta_{2D}, h_{1D})$: exchange exists only when
+  either side reaches the ground. Street drainage into a node whose
+  water stands below its rim is **not modelled** (recorded in §15.10).
+  The predecessor's source calls this elevation the node's "crown"; the
+  value is the rim, and this specification says rim, because §6 already
+  uses *crown* for a conduit soffit and the two must not be confused.
+- $R_{wet}$: the §15.4.3 cubic ramp on the source side's depth, so a
+  draining film shuts off smoothly.
+- $A_{\!e}$: the authored exchange area, ramped from $1\times$ to
+  $2\times$ over the first 50 mm above ground. Under `COUPLING_AREA
+  AUTO`, unauthored areas derive from the node's largest connected
+  conduit: $\mathrm{clamp}(1.25\,A_{conduit},\ 0.05,\ 2.0)$ m².
+
+Positive $Q$ drains the surface into the node; negative spills the node
+onto the surface. Two hard caps bound the exchange: a drain takes at
+most a $\beta$ share of the source cell's volume per substep, and a
+spill draws against the node's stored volume through a per-node ledger
+spanning the whole advance — the same water cannot spill twice within
+one routing step.
+
+**Damping into the network iteration.** The exchange enters the §6.4
+vertex update as a lagged source, and a lagged source with a steep
+head-sensitivity destabilises the iteration it feeds. The exchange
+conductance $G = -\partial Q / \partial h_{1D} \geq 0$ (the ramp and gate
+derivatives dropped, so $G$ only ever adds damping) therefore augments
+the vertex's storage term: the §6.4 update at a coupled vertex uses
+$A_{\!s} + G\,\Delta t$ in place of its surface area $A_{\!s}$. A coupled
+vertex additionally reports the median-dual footprint of its surrounding
+cells ($\sum A_i / 3$ over the vertex's incident cells) as its ponded
+area, and is ponding-capable **regardless of the model's global ponding
+option** — §6.6's gate does not apply at a coupled vertex, because the
+pond is not a modelling choice there: it is the overland surface itself,
+and the network's grade must track it.
+
+> **CORRESPONDENCE:** the predecessor overrides the node's ponded area
+> the same way and documents the consequence: the near-node storage is
+> counted on both sides of the coupling. This engine adopts the
+> mechanism and the acknowledgement; removing the double count is a
+> recorded refinement, not an implementation liberty.
+
+**Outfall coupling** is asymmetric. Surface→network: a coupled outfall's
+boundary stage reads the surface (the deepest wet stencil cell's
+surface, blended in by a wetness ramp; a dry stencil leaves the authored
+stage), evaluated inside each network iteration; a flap gate suppresses
+the override when the surface stands above the authored stage.
+Network→surface: the outfall's discharge over the step is accumulated in
+volume, capped against a per-cell budget frozen at the step's start, and
+injected into the surface as a constant rate over the following step.
+
+**Timing.** By default the surface co-advances **once per §10 routing
+period** — the model's routing-step clock, not §6.5's adaptive steps,
+which subdivide the period on their own error control: the network
+advances the period with the surface frozen, then the surface advances
+the same interval with the node grades frozen, then the exchanged
+volumes queue as network lateral inflow delivered over the next period.
+`COUPLING_SYNC` widens the batch in elapsed time (clamped to the band from one routing
+period to 60 s) for models where the surface advance dominates; batching
+delays delivery by one batch, and the predecessor's measurements record
+fill-and-spill ponds turning into overshoot sawtooth at wide batches —
+which is why per-period is the default. Exchange and boundary
+evaluation happen at tier-0 cadence within the advance, sequentially.
+
+### 15.7 Meteorology on the Mesh
+
+**Rainfall** reaches cells directly, under `RAINFALL_MODE`:
+
+- `NATURAL_NEIGHBOUR` (default): gauge intensities interpolate to cell
+  centroids by Laplace (non-Sibsonian) natural-neighbour weights within
+  the convex hull of the located gauges, inverse-distance-squared
+  outside it. Gauge positions come from the model's display symbols —
+  the one place a display section acquires engine semantics, recorded
+  as §14.15's amendment to §14.5's rule — and gauges without a position
+  are excluded. The weights reproduce linear
+  fields exactly inside the hull and are precomputed once. Degenerate
+  gauge sets fall back: one gauge serves everywhere; collinear or paired
+  gauges serve by inverse distance; no located gauge falls back to
+  `SYSTEM`.
+- `SYSTEM`: the arithmetic mean of all gauges, uniformly.
+- `NONE`: no rain on the mesh — the mode for models whose parcels
+  already capture the storm, where rain-on-mesh would count the same
+  water twice.
+
+A model carrying both parcels (§3) and rain-on-mesh over the same
+footprint double-counts that rainfall; import warns (§14.15), and
+nothing subtracts one from the other. Parcel runoff does **not** flow
+onto the mesh (§15.10): parcels drain to nodes exactly as without a
+mesh, and reach the surface only through a coupled node's exchange.
+
+**Evaporation** applies the §3 potential rate through the §15.4.3 ramp.
+**Infiltration on the mesh is not modelled** (§15.10): the mesh has no
+soil column, and water on the surface leaves only by evaporation,
+conveyance, boundaries, or the network.
+
+### 15.8 Conservation
+
+The overland ledger carries, in cubic metres over the reporting window:
+initial and final surface storage, rainfall in, evaporation out,
+exchange in and out with the network (junctions and outfalls
+separately), and boundary in and out. Interior conveyance never appears:
+each interior edge books one antisymmetric mass pair, so interior
+transport conserves exactly, at every tier interface, by construction —
+and the continuity report measures only what crosses the subsystem's
+boundary. Every exchange term books the volume *actually applied* after
+its caps and clamps, never the volume requested.
+
+On the network side, the exchange enters §11's ledger as its own named
+pair — surface drainage (in) and surface spill (out) — rather than
+folding into existing terms.
+
+> **CORRESPONDENCE:** the predecessor books 1D→2D spill into its node
+> flooding total and 2D→1D drainage into external inflow, so a coupled
+> run's "flooding" silently includes water the surface later returned.
+> This engine gives the exchange its own ledger lines; readers comparing
+> continuity reports across engines must add the predecessor's exchange
+> shares back out of its flooding and inflow totals.
+
+### 15.9 Verification
+
+Three families gate this section, in the §1.8 sense that an
+unimplemented gate is an unserved capability:
+
+**Analytic.** The SWASHES library (Delestre et al. 2013), graded on
+relative $L^1$ depth error and mass error against independently
+implemented reference solutions: lake at rest over immersed and emerged
+bumps (exact to round-off — the well-balancing property, which the
+deadband and face-gating exist to protect); subcritical flow over a bump
+(≲ 1%, the residual being the omitted velocity-head dip); MacDonald
+subcritical profile (≲ 2%). Transcritical, dam-break, and oscillating
+(Thacker) cases are graded against recorded baselines rather than
+analytic solutions while the convective term is optional, and the
+supercritical MacDonald profile is an **expected failure**, recorded as
+the boundary of validity.
+
+**Conservation.** A closed basin conserves volume to $10^{-10}$
+relative; every ledger term above closes against the state it describes;
+tier-interface accounting is exact; the local-time-stepping march agrees
+with the single-tier march.
+
+**Determinism.** Byte-identical results at every §6.4 width, results
+and report both; SI and US-unit authorings of one physical model agree
+to round-trip precision.
+
+### 15.10 Recorded Gaps and Deferrals
+
+Typed, per §1.8 — each is a named absence, not an approximation:
+
+- **Time-series results for the mesh.** The predecessor writes
+  CF/UGRID HDF5. This engine's overland results surface — format,
+  cadence, and its relation to §14.9's results stream — is a recorded
+  gap, to be specified before the output phase implements anything. A
+  heavyweight native-library dependency conflicts with the browser
+  build's constraints (§1.4), and the resolution is a specification
+  decision, not an implementation one.
+- **Checkpoint carriage.** §12.3 checkpoints do not yet carry overland
+  state; a run with a mesh refuses checkpointing until they do (format
+  version bump when it lands). The predecessor's hotstart files have the
+  same gap.
+- **Sub-rim street drainage.** Junction exchange opens only at the
+  rim; a surface film over a node whose water stands below ground does
+  not drain into it.
+- **Runoff-to-mesh.** Parcel runoff routes to nodes only.
+- **Mesh infiltration**, **overland constituent transport**, **mesh
+  adaptivity**: absent here as in the predecessor.
+- **Report additions.** The §14.9 run summary gains the overland
+  continuity block and solver statistics when §15 is served; their
+  layout is specified with the §15.8 accounting's implementation, not
+  before.
+- **Device compute.** The marcher's kernels are specified as pure
+  per-element maps over flat state, which is deliberately the shape a
+  GPU backend could lift without restructuring. None is planned: the
+  engine's double-precision rule has no efficient home on consumer or
+  Apple GPUs, cross-device bit-identity is unattainable, and the
+  predecessor's own measurements show device launch overhead losing to
+  a hot processor team below hundreds of thousands of cells. A device
+  backend, if one ever earns its place, would be a separately labelled
+  mode for datacenter-class hardware, never the reported result's
+  default path.
+- **Format churn.** The predecessor is pre-release; §14.15's retired-key
+  mechanism absorbs option-vocabulary changes, and structural format
+  changes are adopted deliberately, by amending this specification.

--- a/crates/engine-uds/src/overland/spec.md
+++ b/crates/engine-uds/src/overland/spec.md
@@ -356,11 +356,13 @@ condition addresses its (cell, edge) slot. Five types:
 | `WALL` | $F = 0$ |
 | `NORMAL_FLOW` | Manning outfall at the authored bed slope $S$: $F = -\dfrac{h^{5/3}\sqrt{S}}{n}\,\xi$ |
 | `SPECIFIED_FLOW` | $F = -q_{bc}\,\xi$, $q_{bc}$ the authored (or time-series) per-metre discharge |
-| `RATING_CURVE` | as `SPECIFIED_FLOW` with $q_{bc}$ read from a curve of stage above the edge bed |
+| `RATING_CURVE` | as `SPECIFIED_FLOW` with $q_{bc}$ read from a curve of stage above the edge bed — the edge's sill, its higher endpoint elevation, the §15.3 face datum — interpolated linearly and held at its end values beyond its range, re-read every firing because stage is state, not time |
 | `SPECIFIED_STAGE` | the §15.4.2 momentum law against a ghost cell held at the authored (or time-series) stage, slope arm $d_n = 2A/(3\xi)$, the cell's own $n^2$, prognostic discharge |
 
 $h$ is the cell-mean depth under `MEAN` reconstruction and the wetted-edge
-depth under `VFR_FACE`. All boundary applications clamp in volume
+depth under `VFR_FACE`. A time-series stage or flow resolves to a value
+per advance at the wiring layer; until its first resolution the slot is
+a wall, the refusal-safe reading of an unresolved parameter. All boundary applications clamp in volume
 space — a cell cannot be driven negative, and one substep of a stage
 boundary moves its cell at most **to** the prescribed stage, from
 either side — and the flux booked to the §15.8 ledger is re-derived
@@ -385,12 +387,18 @@ cadence, sequentially.
 The overland surface and the §6 network exchange at **coupling points**:
 authored mappings from a mesh vertex or cell to a network node (§14.15).
 Nothing couples implicitly — an unmapped node never exchanges. A vertex
-mapping conveys through the vertex's incident-cell stencil; for junction
-exchange the stencil collapses to its lowest-bed cell (where water
-actually pools), while volume scattering spreads across the stencil
-weighted by the surface slope toward each cell (downhill for arriving
-water, uphill for draining), falling back to geometric weights on a flat
-surface.
+mapping conveys through the vertex's incident-cell stencil, collapsed
+for junction exchange to its lowest-bed cell: that is where water
+actually pools, and a single source cell is what the drain cap is
+written against — both directions of the orifice exchange apply there.
+Outfall injection (network→surface, below) instead spreads across the
+stencil, weighted by the surface slope from the vertex down toward each
+cell ($w_k = \max(0, (\eta_v - \eta_k)/d_k)$, $d_k$ the distance from
+the vertex to the cell centroid, $\eta_v$ the wet-depth-weighted mean
+surface of the vertex's wet incident cells, or the vertex ground
+elevation when all are dry), falling back to area weights on a flat or
+dry surface. Two rows resolving to one vertex are one coupling, the
+last authored winning (§14.15).
 
 **Junction exchange** is one orifice law for both directions. With
 $\Delta h = \eta_{2D} - h_{1D}$ (the overland surface against the node's
@@ -452,7 +460,12 @@ and the network's grade must track it.
 boundary stage reads the surface (the deepest wet stencil cell's
 surface, blended in by a wetness ramp; a dry stencil leaves the authored
 stage), evaluated inside each network iteration; a flap gate suppresses
-the override when the surface stands above the authored stage.
+the override when the surface stands above the stage the outfall would
+otherwise carry. The ramp is keyed on the depth in excess of the drying
+depth, $t = (d - h_{dry})/h_{dry}$ smoothstepped: a draining cell comes
+to rest holding a film at about the drying depth, and a ramp keyed on
+the raw depth would read that immovable film as wet and deadlock the
+outfall at its own bed (a measured predecessor failure).
 Network→surface: the outfall's discharge over the step is accumulated in
 volume, capped against a per-cell budget frozen at the step's start, and
 injected into the surface as a constant rate over the following step.

--- a/crates/engine-uds/src/simulation/checkpoint.rs
+++ b/crates/engine-uds/src/simulation/checkpoint.rs
@@ -24,7 +24,7 @@ pub const STAMP: &[u8] = b"HYDRA-UDS-CHECKPOINT";
 /// checkpoint of any other version is refused rather than guessed at.
 /// v2: the swale's cross-step rate left the state — the §3.4 advance
 /// now uses this step's own start-of-step rate, which is not state.
-pub const VERSION: u32 = 3;
+pub const VERSION: u32 = 4;
 
 /// A 64-bit FNV-1a hash, used to fingerprint a model's identifiers.
 ///

--- a/crates/engine-uds/src/simulation/coupled.rs
+++ b/crates/engine-uds/src/simulation/coupled.rs
@@ -87,6 +87,9 @@ impl CoupledSurface {
                 marcher.mark_outfall_slot(slot);
             }
         }
+        // §15.4.5: the march takes the model's §6.4 worker width.
+        #[cfg(feature = "threads")]
+        marcher.set_width(net.options.threads as usize);
         let pending = vec![0.0; slot_vertex.len()];
         let outfall_pending = vec![0.0; slot_vertex.len()];
         Ok(CoupledSurface {
@@ -519,6 +522,79 @@ C1  CIRCULAR  0.5  0  0  0
         assert!(
             (v0 - m.storage() - (m.coupling_out - m.coupling_in)).abs() < 1e-9,
             "surface ledger"
+        );
+    }
+
+    /// §15.9 determinism: SI and US authorings of one physical model
+    /// agree to round-trip precision. The mesh is SI either way
+    /// (§14.15); only the network sections convert.
+    #[test]
+    fn si_and_us_authorings_agree() {
+        let run = |inp: &str| {
+            let (mut sim, _, findings) = crate::simulation::Simulation::open(inp).expect("open");
+            assert!(findings.iter().all(|f| !f.kind.is_error()), "{findings:?}");
+            sim.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
+            sim.run();
+            let m = &sim.overland().expect("attached").marcher;
+            (m.storage(), m.coupling_out)
+        };
+        let si = run("\
+[OPTIONS]
+FLOW_UNITS    CMS
+START_DATE    06/01/2024
+START_TIME    00:00
+END_DATE      06/01/2024
+END_TIME      00:20
+ROUTING_STEP  5
+REPORT_STEP   0:05:00
+
+[JUNCTIONS]
+J1  100.0  2.0
+
+[OUTFALLS]
+O1  99.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.5  0  0  0
+");
+        // The same model in feet: every length is the exact conversion
+        // of the metric authoring.
+        let us = run("\
+[OPTIONS]
+FLOW_UNITS    CFS
+START_DATE    06/01/2024
+START_TIME    00:00
+END_DATE      06/01/2024
+END_TIME      00:20
+ROUTING_STEP  5
+REPORT_STEP   0:05:00
+
+[JUNCTIONS]
+J1  328.0839895013123  6.561679790026246
+
+[OUTFALLS]
+O1  324.8031496062992  FREE
+
+[CONDUITS]
+C1  J1  O1  328.0839895013123  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  1.6404199475065617  0  0  0
+");
+        assert!(
+            (si.0 - us.0).abs() <= 1e-6 * si.0.max(1e-9),
+            "storage: SI {} vs US {}",
+            si.0,
+            us.0
+        );
+        assert!(
+            (si.1 - us.1).abs() <= 1e-6 * si.1.max(1e-9),
+            "drained: SI {} vs US {}",
+            si.1,
+            us.1
         );
     }
 

--- a/crates/engine-uds/src/simulation/coupled.rs
+++ b/crates/engine-uds/src/simulation/coupled.rs
@@ -1,0 +1,552 @@
+//! §15.6: the surface↔network co-advance.
+//!
+//! One struct owns the overland marcher and the per-period exchange
+//! bookkeeping: the network advances a §10 routing period with the
+//! surface frozen, the surface advances the same interval with the node
+//! grades frozen, and the exchanged volumes queue as network lateral
+//! inflow delivered over the next period. Everything here is SI.
+
+use crate::hydraulics::routing::Router;
+use crate::model::Network;
+use crate::overland::marcher::Marcher;
+
+/// A coupled node the marcher's slot order could not resolve against
+/// the network's vertex identifiers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownCouplingNode {
+    pub node: String,
+}
+
+/// Why an overland mesh could not be attached to a session.
+#[derive(Debug)]
+pub enum AttachError {
+    /// The mesh failed §15.2 validation.
+    Mesh(Vec<crate::overland::MeshError>),
+    /// A coupling row names a network node the model does not have.
+    UnknownNode(String),
+    /// A boundary row names a time series the model does not have.
+    UnknownSeries(String),
+    /// A boundary row names a curve the model does not have.
+    UnknownCurve(String),
+}
+
+/// §15.6: the overland surface coupled to the routed network.
+pub struct CoupledSurface {
+    pub marcher: Marcher,
+    /// Router vertex per marcher slot.
+    slot_vertex: Vec<usize>,
+    /// Exchanged volume awaiting delivery as next period's lateral
+    /// (m³ per slot, positive = into the node).
+    pending: Vec<f64>,
+    /// §15.6: outfall discharge awaiting injection over the next batch
+    /// (m³ per slot, positive = onto the surface).
+    outfall_pending: Vec<f64>,
+    /// §15.8 running totals of the exchange as DELIVERED to the network
+    /// ledger: surface drainage in, surface spill drawn back out (m³).
+    pub delivered_in: f64,
+    pub delivered_out: f64,
+}
+
+impl CoupledSurface {
+    /// Resolve the marcher's coupled node names against the network and
+    /// mark each router vertex coupled: its ponded area becomes the
+    /// §15.6 footprint (the median-dual $\sum A_i/3$ of a vertex
+    /// point's stencil; a cell point's whole cell), summed over the
+    /// points naming it.
+    pub fn new(
+        marcher: Marcher,
+        net: &Network,
+        router: &mut Router,
+    ) -> Result<CoupledSurface, UnknownCouplingNode> {
+        let mut slot_vertex = Vec::with_capacity(marcher.coupling_nodes().len());
+        for name in marcher.coupling_nodes() {
+            let Some(vi) = net.vertices.iter().position(|v| &v.id == name) else {
+                return Err(UnknownCouplingNode { node: name.clone() });
+            };
+            slot_vertex.push(vi);
+        }
+        let mut footprint = vec![0.0; slot_vertex.len()];
+        for cp in marcher.coupling_points() {
+            let a: f64 = cp.stencil.iter().map(|&ci| marcher.area[ci as usize]).sum();
+            footprint[cp.node_slot as usize] += if cp.vertex.is_some() { a / 3.0 } else { a };
+        }
+        for (slot, &vi) in slot_vertex.iter().enumerate() {
+            router.set_coupled(vi, footprint[slot]);
+        }
+        // §15.6: outfall coupling is asymmetric — mark those slots so
+        // the marcher leaves them to the stage and injection paths.
+        let mut marcher = marcher;
+        for (slot, &vi) in slot_vertex.iter().enumerate() {
+            if matches!(
+                net.vertices[vi].kind,
+                crate::model::VertexKind::Outfall { .. }
+            ) {
+                marcher.mark_outfall_slot(slot);
+            }
+        }
+        let pending = vec![0.0; slot_vertex.len()];
+        let outfall_pending = vec![0.0; slot_vertex.len()];
+        Ok(CoupledSurface {
+            marcher,
+            slot_vertex,
+            pending,
+            outfall_pending,
+            delivered_in: 0.0,
+            delivered_out: 0.0,
+        })
+    }
+
+    /// §15.6: the surface tailwater at each coupled outfall — the
+    /// deepest wet stencil cell's surface, with the wetness ramp keyed
+    /// on depth in excess of the drying depth — pushed to the router
+    /// for the coming period's boundary evaluations.
+    fn set_outfall_tailwaters(&self, router: &mut Router) {
+        let m = &self.marcher;
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            if !m.is_outfall_slot(slot) {
+                continue;
+            }
+            let (mut h_2d, mut depth) = (f64::NEG_INFINITY, 0.0_f64);
+            for cp in m.coupling_points() {
+                if cp.node_slot as usize != slot {
+                    continue;
+                }
+                for &ci in &cp.stencil {
+                    let ci = ci as usize;
+                    if m.depth[ci] > depth {
+                        depth = m.depth[ci];
+                        h_2d = m.eta[ci];
+                    }
+                }
+            }
+            let t = ((depth - m.dry_depth()) / m.dry_depth()).clamp(0.0, 1.0);
+            let ramp = t * t * (3.0 - 2.0 * t);
+            router.set_outfall_tailwater(vi, h_2d, ramp);
+        }
+    }
+
+    /// §15.6: deliver the last period's exchanged volumes into this
+    /// period's lateral vector as constant rates — positive exchange
+    /// (surface drained into the node) is lateral inflow, a spill is
+    /// its negative, drawing the node down by what it spilled.
+    pub fn deliver_laterals(&mut self, lat: &mut [f64], period: f64) {
+        for (slot, p) in self.pending.iter_mut().enumerate() {
+            if *p != 0.0 {
+                lat[self.slot_vertex[slot]] += *p / period;
+                // §15.8: the exchange is its own named ledger pair on
+                // the network side, never folded into external inflow.
+                if *p > 0.0 {
+                    self.delivered_in += *p;
+                } else {
+                    self.delivered_out += -*p;
+                }
+                *p = 0.0;
+            }
+        }
+    }
+
+    /// §15.6: co-advance the surface over the period the network just
+    /// finished — node grades frozen at the router's current state —
+    /// bank the exchange for next period's laterals, and refresh each
+    /// coupled vertex's damping conductance for the coming period.
+    pub fn co_advance(&mut self, router: &mut Router, period: f64) {
+        // §15.6: last batch's outfall discharge injects as a constant
+        // rate over this batch, scattered down the surface slope.
+        self.marcher.clear_injection();
+        let points: Vec<(usize, usize)> = self
+            .marcher
+            .coupling_points()
+            .iter()
+            .enumerate()
+            .map(|(k, cp)| (k, cp.node_slot as usize))
+            .collect();
+        for (slot, p) in self.outfall_pending.iter_mut().enumerate() {
+            if *p == 0.0 {
+                continue;
+            }
+            let mine: Vec<usize> = points
+                .iter()
+                .filter(|(_, s)| *s == slot)
+                .map(|(k, _)| *k)
+                .collect();
+            let share = *p / period / mine.len().max(1) as f64;
+            for k in mine {
+                self.marcher.inject(k, share);
+            }
+            *p = 0.0;
+        }
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            if self.marcher.is_outfall_slot(slot) {
+                continue;
+            }
+            let invert = router.vertex_invert(vi);
+            let y = router.depth(vi);
+            let rim = invert + router.vertex_max_depth(vi);
+            self.marcher
+                .set_node_drive(slot, invert + y, y, rim, router.vertex_volume_now(vi));
+        }
+        self.marcher.advance(period);
+        for (k, &dv) in self.marcher.exchanged().iter().enumerate() {
+            let slot = self.marcher.coupling_points()[k].node_slot as usize;
+            self.pending[slot] += dv;
+        }
+        // Damping for the coming period, §6.4: the summed conductance of
+        // every point naming the vertex, against the live surface.
+        let mut g = vec![0.0; self.slot_vertex.len()];
+        for k in 0..self.marcher.coupling_points().len() {
+            let slot = self.marcher.coupling_points()[k].node_slot as usize;
+            if !self.marcher.is_outfall_slot(slot) {
+                g[slot] += self.marcher.coupling_conductance(k);
+            }
+        }
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            router.set_coupling_conductance(vi, g[slot]);
+        }
+        // §15.6: bank each coupled outfall's net discharge over this
+        // period for the next batch's injection. A withdrawal (the
+        // surface pushing into the network through the boundary) is
+        // capped against the β share of the stencil's frozen volume.
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            if !self.marcher.is_outfall_slot(slot) {
+                continue;
+            }
+            let mut vol = router.vertex_net_link_inflow(vi) * period;
+            if vol < 0.0 {
+                let held: f64 = self
+                    .marcher
+                    .coupling_points()
+                    .iter()
+                    .filter(|cp| cp.node_slot as usize == slot)
+                    .flat_map(|cp| cp.stencil.iter())
+                    .map(|&ci| self.marcher.vol[ci as usize].max(0.0))
+                    .sum();
+                vol = vol.max(-0.8 * held);
+            }
+            self.outfall_pending[slot] += vol;
+        }
+        // The surface the network sees next period.
+        self.set_outfall_tailwaters(router);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::objects::parse_network;
+    use crate::io::validate::validate;
+    use crate::overland::{CouplingRow, MeshCell, MeshVertex, OverlandMesh, Topology};
+
+    const NET: &str = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+ROUTING_STEP  5
+
+[JUNCTIONS]
+J1  100.0  2.0
+
+[OUTFALLS]
+O1  99.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.5  0  0  0
+";
+
+    fn network() -> (Network, Router) {
+        let (mut net, diags) = parse_network(NET);
+        assert!(!diags.iter().any(|d| d.kind.is_error()), "{diags:?}");
+        let v = validate(&mut net);
+        assert!(v.iter().all(|f| !f.kind.is_error()), "{v:?}");
+        let router = Router::build(&net).expect("router");
+        (net, router)
+    }
+
+    /// A flat pond at the junction's ground elevation, coupled at one
+    /// cell.
+    fn pond_mesh(h0: f64, node: &str) -> OverlandMesh {
+        let mut mesh = OverlandMesh::default();
+        let (nx, ny, dx) = (4usize, 4usize, 1.0);
+        let nvx = nx + 1;
+        for j in 0..=ny {
+            for i in 0..=nx {
+                mesh.verts.push(MeshVertex {
+                    x: dx * i as f64,
+                    y: dx * j as f64,
+                    z: 102.0,
+                    tag: None,
+                });
+            }
+        }
+        for j in 0..ny {
+            for i in 0..nx {
+                let v00 = (j * nvx + i) as u32;
+                let v10 = (j * nvx + i + 1) as u32;
+                let v01 = ((j + 1) * nvx + i) as u32;
+                let v11 = ((j + 1) * nvx + i + 1) as u32;
+                for tri in [[v00, v10, v11], [v00, v11, v01]] {
+                    mesh.cells.push(MeshCell {
+                        v: tri,
+                        n: 0.05,
+                        h0,
+                        tag: None,
+                    });
+                }
+            }
+        }
+        mesh.cell_couplings.push(CouplingRow {
+            address: "0".into(),
+            node: node.into(),
+            cd: 0.65,
+            area: 0.05,
+            area_authored: true,
+        });
+        mesh
+    }
+
+    fn marcher_of(mesh: &OverlandMesh) -> Marcher {
+        let topo = Topology::build(mesh).expect("valid mesh");
+        Marcher::build(mesh, &topo)
+    }
+
+    /// An unknown coupled node name is a refusal, not a silent skip.
+    #[test]
+    fn an_unknown_coupling_node_refuses() {
+        let (net, mut router) = network();
+        let m = marcher_of(&pond_mesh(0.3, "NOPE"));
+        let err = CoupledSurface::new(m, &net, &mut router)
+            .err()
+            .expect("refusal");
+        assert_eq!(err.node, "NOPE");
+    }
+
+    /// §15.6 end to end: a surface pond drains through the coupling,
+    /// arrives as next-period lateral inflow, and leaves through the
+    /// outfall — every exchanged litre accounted on both sides.
+    #[test]
+    fn a_pond_drains_into_the_network_and_out_the_outfall() {
+        let (net, mut router) = network();
+        let m = marcher_of(&pond_mesh(0.3, "J1"));
+        let mut cs = CoupledSurface::new(m, &net, &mut router).expect("resolves");
+        let v0 = cs.marcher.storage();
+        assert!(v0 > 4.7 && v0 < 4.9, "pond holds {v0}");
+
+        let nv = 2;
+        let period = 5.0;
+        let mut delivered = 0.0;
+        let mut t = 0.0;
+        for _ in 0..240 {
+            let mut lat = vec![0.0; nv];
+            cs.deliver_laterals(&mut lat, period);
+            delivered += lat[0] * period;
+            t += period;
+            router.advance(t, &move |_tt, l: &mut [f64]| l.copy_from_slice(&lat));
+            cs.co_advance(&mut router, period);
+        }
+
+        // The pond drained through the orifice.
+        assert!(
+            cs.marcher.storage() < 0.05 * v0,
+            "pond still holds {}",
+            cs.marcher.storage()
+        );
+        // Surface ledger: what left the surface is what the coupling
+        // booked.
+        let drained = cs.marcher.coupling_out - cs.marcher.coupling_in;
+        assert!(
+            (v0 - cs.marcher.storage() - drained).abs() < 1e-9,
+            "surface ledger"
+        );
+        // Delivery: everything banked was delivered (the last period's
+        // pending may still be in flight).
+        assert!(
+            (delivered - drained).abs() <= cs.pending.iter().map(|p| p.abs()).sum::<f64>() + 1e-9,
+            "delivered {delivered} vs drained {drained}"
+        );
+        // Network ledger: the inflow arrived and left through the
+        // outfall (5% closure over a transient run).
+        let led = &router.report;
+        assert!(
+            (led.inflow - delivered).abs() < 1e-6,
+            "router saw {} of {delivered}",
+            led.inflow
+        );
+        assert!(
+            (led.inflow - led.outflow).abs() < 0.05 * led.inflow.max(1e-9),
+            "in {} out {}",
+            led.inflow,
+            led.outflow
+        );
+    }
+
+    /// A pond mesh whose bed sits at the outfall's ground: the same
+    /// helper geometry, rebased.
+    fn low_mesh(h0: f64, node: &str) -> OverlandMesh {
+        let mut mesh = pond_mesh(h0, node);
+        for v in &mut mesh.verts {
+            v.z = 99.0;
+        }
+        mesh
+    }
+
+    /// §15.6: a coupled outfall's discharge injects onto the surface
+    /// over the following batch, and the surface books every litre.
+    #[test]
+    fn an_outfall_discharges_onto_the_surface() {
+        let (net, mut router) = network();
+        let m = marcher_of(&low_mesh(0.0, "O1"));
+        let mut cs = CoupledSurface::new(m, &net, &mut router).expect("resolves");
+        let period = 5.0;
+        let mut t = 0.0;
+        for _ in 0..120 {
+            let mut lat = vec![0.0; 2];
+            cs.deliver_laterals(&mut lat, period);
+            lat[0] += 0.05;
+            t += period;
+            router.advance(t, &move |_tt, l: &mut [f64]| l.copy_from_slice(&lat));
+            cs.co_advance(&mut router, period);
+        }
+        assert!(
+            cs.marcher.outfall_in > 0.0,
+            "the outfall never reached the surface"
+        );
+        // §15.8: the injection path books apart from the junction
+        // exchange, and the surface holds what it says.
+        assert_eq!(cs.marcher.coupling_in, 0.0);
+        assert!(
+            (cs.marcher.storage() - cs.marcher.outfall_in).abs() < 1e-9,
+            "surface {} vs injected {}",
+            cs.marcher.storage(),
+            cs.marcher.outfall_in
+        );
+        // And what was injected tracks what the network discharged
+        // (one batch may still be pending).
+        let led = &router.report;
+        assert!(
+            (led.outflow - cs.marcher.outfall_in).abs()
+                < 0.1 * led.outflow + cs.outfall_pending[0].abs() + 1e-9,
+            "network discharged {} but the surface got {}",
+            led.outflow,
+            cs.marcher.outfall_in
+        );
+    }
+
+    /// §15.6: a flooded surface over a coupled outfall sets its
+    /// boundary stage — the network sees the pond as tailwater.
+    #[test]
+    fn a_flooded_surface_sets_the_outfall_tailwater() {
+        let (net, mut router) = network();
+        let m = marcher_of(&low_mesh(1.0, "O1"));
+        let mut cs = CoupledSurface::new(m, &net, &mut router).expect("resolves");
+        // One co-advance publishes the tailwater; the next network
+        // period evaluates its boundary against it.
+        cs.co_advance(&mut router, 5.0);
+        let lat = vec![0.05, 0.0];
+        router.advance(5.0, &move |_tt, l: &mut [f64]| l.copy_from_slice(&lat));
+        // O1 (vertex 1, invert 99) reads the pond: depth ≈ 1 m.
+        assert!(
+            router.depth(1) > 0.9,
+            "outfall depth {} ignores the pond",
+            router.depth(1)
+        );
+    }
+
+    /// §15.6 through the whole session: a mesh attached to a live
+    /// `Simulation` drains its pond into the network across `step()`
+    /// periods — delivery, damping, checkpoint refusal and all.
+    #[test]
+    fn a_session_runs_the_coupled_surface_through_its_steps() {
+        let inp = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+START_DATE    06/01/2024
+START_TIME    00:00
+END_DATE      06/01/2024
+END_TIME      00:20
+ROUTING_STEP  5
+REPORT_STEP   0:05:00
+
+[JUNCTIONS]
+J1  100.0  2.0
+
+[OUTFALLS]
+O1  99.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.5  0  0  0
+";
+        let (mut sim, _, findings) = crate::simulation::Simulation::open(inp).expect("open");
+        assert!(findings.iter().all(|f| !f.kind.is_error()));
+        sim.attach_overland(&pond_mesh(0.3, "J1")).expect("attach");
+        let v0 = sim.overland().expect("attached").marcher.storage();
+
+        // §15.10: a mesh run refuses checkpointing, by name.
+        let mut sink = Vec::new();
+        let err = sim.save_checkpoint(&mut sink).expect_err("refusal");
+        assert!(err.contains("overland mesh"), "{err}");
+
+        sim.run();
+        let m = &sim.overland().expect("attached").marcher;
+        assert!(
+            m.storage() < 0.2 * v0,
+            "pond still holds {} of {v0}",
+            m.storage()
+        );
+        assert!(
+            (v0 - m.storage() - (m.coupling_out - m.coupling_in)).abs() < 1e-9,
+            "surface ledger"
+        );
+    }
+
+    /// §15.6 the other direction: a surcharged node spills onto the
+    /// surface, the spill draws the node's delivered lateral negative,
+    /// and the surface gains exactly what the ledger booked.
+    #[test]
+    fn a_surcharged_node_spills_onto_the_surface() {
+        let (net, mut router) = network();
+        let m = marcher_of(&pond_mesh(0.0, "J1"));
+        let mut cs = CoupledSurface::new(m, &net, &mut router).expect("resolves");
+
+        let nv = 2;
+        let period = 5.0;
+        let mut t = 0.0;
+        let mut delivered_neg = 0.0;
+        for _ in 0..120 {
+            let mut lat = vec![0.0; nv];
+            cs.deliver_laterals(&mut lat, period);
+            if lat[0] < 0.0 {
+                delivered_neg += -lat[0] * period;
+            }
+            // Far above the little pipe's capacity: the coupled vertex
+            // ponds above its rim and reaches the surface.
+            lat[0] += 1.0;
+            t += period;
+            router.advance(t, &move |_tt, l: &mut [f64]| l.copy_from_slice(&lat));
+            cs.co_advance(&mut router, period);
+        }
+        assert!(
+            cs.marcher.coupling_in > 0.0,
+            "the node never reached the surface"
+        );
+        assert!(
+            (cs.marcher.storage() - cs.marcher.coupling_in).abs() < 1e-9,
+            "surface gained {} but the ledger says {}",
+            cs.marcher.storage(),
+            cs.marcher.coupling_in
+        );
+        // What spilled was drawn back off the node as negative lateral.
+        assert!(
+            (delivered_neg
+                - (cs.marcher.coupling_in
+                    - cs.pending.iter().map(|p| p.min(0.0)).sum::<f64>().abs()))
+            .abs()
+                < 1e-6,
+            "spill draw-down mismatch: {delivered_neg} vs {}",
+            cs.marcher.coupling_in
+        );
+    }
+}

--- a/crates/engine-uds/src/simulation/coupled.rs
+++ b/crates/engine-uds/src/simulation/coupled.rs
@@ -201,18 +201,7 @@ impl CoupledSurface {
             self.pending[slot] += dv;
             self.report_exchange[k] += dv;
         }
-        // Damping for the coming period, §6.4: the summed conductance of
-        // every point naming the vertex, against the live surface.
-        let mut g = vec![0.0; self.slot_vertex.len()];
-        for k in 0..self.marcher.coupling_points().len() {
-            let slot = self.marcher.coupling_points()[k].node_slot as usize;
-            if !self.marcher.is_outfall_slot(slot) {
-                g[slot] += self.marcher.coupling_conductance(k);
-            }
-        }
-        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
-            router.set_coupling_conductance(vi, g[slot]);
-        }
+        self.refresh_conductances(router);
         // §15.6: bank each coupled outfall's net discharge over this
         // period for the next batch's injection. A withdrawal (the
         // surface pushing into the network through the boundary) is
@@ -237,6 +226,165 @@ impl CoupledSurface {
         }
         // The surface the network sees next period.
         self.set_outfall_tailwaters(router);
+    }
+
+    /// §6.4 damping for the coming period: the summed conductance of
+    /// every point naming the vertex, against the live surface.
+    fn refresh_conductances(&self, router: &mut Router) {
+        let mut g = vec![0.0; self.slot_vertex.len()];
+        for k in 0..self.marcher.coupling_points().len() {
+            let slot = self.marcher.coupling_points()[k].node_slot as usize;
+            if !self.marcher.is_outfall_slot(slot) {
+                g[slot] += self.marcher.coupling_conductance(k);
+            }
+        }
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            router.set_coupling_conductance(vi, g[slot]);
+        }
+    }
+
+    /// §12.3: re-derive what a checkpoint does not carry because the
+    /// restored halves already hold it — the marcher's node drives from
+    /// the restored router, and the router's damping conductances and
+    /// outfall tailwaters from the restored surface — exactly the
+    /// values the interrupted run's last co-advance left in place.
+    pub fn resync_network(&mut self, router: &mut Router) {
+        for (slot, &vi) in self.slot_vertex.iter().enumerate() {
+            if self.marcher.is_outfall_slot(slot) {
+                continue;
+            }
+            let invert = router.vertex_invert(vi);
+            let y = router.depth(vi);
+            let rim = invert + router.vertex_max_depth(vi);
+            self.marcher
+                .set_node_drive(slot, invert + y, y, rim, router.vertex_volume_now(vi));
+        }
+        self.refresh_conductances(router);
+        self.set_outfall_tailwaters(router);
+    }
+
+    /// §12.3: write the overland state — the marcher's physical and
+    /// cadence state, the §15.8 ledger and march counters, and this
+    /// struct's exchange bookkeeping — in the checkpoint's framing.
+    pub fn checkpoint_put(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
+        use crate::simulation::checkpoint as cp;
+        let m = &self.marcher;
+        for vs in [&m.vol, &m.q, &m.facc_l, &m.facc_r, &m.qcx, &m.qcy] {
+            cp::put_fs(w, vs)?;
+        }
+        cp::put_fs(w, &m.boundary_discharges())?;
+        cp::put_u(w, m.active.len() as u64)?;
+        for &on in &m.active {
+            cp::put_b(w, on)?;
+        }
+        for &t in &m.tier {
+            cp::put_u(w, u64::from(t))?;
+        }
+        for v in [
+            m.lazy_owed,
+            m.storage0,
+            m.min_dt0,
+            m.advanced,
+            m.rain_in,
+            m.evap_out,
+            m.boundary_in,
+            m.boundary_out,
+            m.coupling_in,
+            m.coupling_out,
+            m.outfall_in,
+            m.outfall_out,
+        ] {
+            cp::put_f(w, v)?;
+        }
+        for v in [m.macro_cycles, m.substeps, m.rebuilds, m.peak_active as u64] {
+            cp::put_u(w, v)?;
+        }
+        for vs in [&self.pending, &self.outfall_pending, &self.report_exchange] {
+            cp::put_fs(w, vs)?;
+        }
+        cp::put_f(w, self.delivered_in)?;
+        cp::put_f(w, self.delivered_out)
+    }
+
+    /// §12.3: restore what [`CoupledSurface::checkpoint_put`] wrote,
+    /// then rebuild everything derivable. Sizes are checked against the
+    /// attached mesh — the fingerprint upstream should have refused a
+    /// mismatch already, so a failure here is a corrupt file.
+    pub fn checkpoint_get(
+        &mut self,
+        r: &mut crate::simulation::checkpoint::Reader<'_>,
+    ) -> Result<(), String> {
+        let m = &mut self.marcher;
+        let (nc, nf, nb) = (m.vol.len(), m.q.len(), m.boundary_discharges().len());
+        let vol = r.fs()?;
+        let q = r.fs()?;
+        let fl = r.fs()?;
+        let fr = r.fs()?;
+        let qcx = r.fs()?;
+        let qcy = r.fs()?;
+        let bq = r.fs()?;
+        if vol.len() != nc
+            || q.len() != nf
+            || fl.len() != nf
+            || fr.len() != nf
+            || qcx.len() != nc
+            || qcy.len() != nc
+            || bq.len() != nb
+        {
+            return Err("checkpoint overland state does not fit this mesh".into());
+        }
+        m.vol = vol;
+        m.q = q;
+        m.facc_l = fl;
+        m.facc_r = fr;
+        m.qcx = qcx;
+        m.qcy = qcy;
+        m.set_boundary_discharges(&bq);
+        let n = r.u()? as usize;
+        if n != nc {
+            return Err("checkpoint overland state does not fit this mesh".into());
+        }
+        for ci in 0..nc {
+            m.active[ci] = r.b()?;
+        }
+        for ci in 0..nc {
+            m.tier[ci] = u8::try_from(r.u()?).map_err(|_| "overland tier out of range")?;
+        }
+        for slot in [
+            &mut m.lazy_owed,
+            &mut m.storage0,
+            &mut m.min_dt0,
+            &mut m.advanced,
+            &mut m.rain_in,
+            &mut m.evap_out,
+            &mut m.boundary_in,
+            &mut m.boundary_out,
+            &mut m.coupling_in,
+            &mut m.coupling_out,
+            &mut m.outfall_in,
+            &mut m.outfall_out,
+        ] {
+            *slot = r.f()?;
+        }
+        m.macro_cycles = r.u()?;
+        m.substeps = r.u()?;
+        m.rebuilds = r.u()?;
+        m.peak_active = r.u()? as usize;
+        m.rebuild_after_restore();
+        let pending = r.fs()?;
+        let outfall_pending = r.fs()?;
+        let report_exchange = r.fs()?;
+        if pending.len() != self.pending.len()
+            || outfall_pending.len() != self.outfall_pending.len()
+        {
+            return Err("checkpoint overland state does not fit this mesh".into());
+        }
+        self.pending = pending;
+        self.outfall_pending = outfall_pending;
+        self.report_exchange = report_exchange;
+        self.delivered_in = r.f()?;
+        self.delivered_out = r.f()?;
+        Ok(())
     }
 
     /// §14.16: the per-point exchanged volumes since the last take
@@ -507,11 +655,6 @@ C1  CIRCULAR  0.5  0  0  0
         sim.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
         let v0 = sim.overland().expect("attached").marcher.storage();
 
-        // §15.10: a mesh run refuses checkpointing, by name.
-        let mut sink = Vec::new();
-        let err = sim.save_checkpoint(&mut sink).expect_err("refusal");
-        assert!(err.contains("overland mesh"), "{err}");
-
         sim.run();
         let m = &sim.overland().expect("attached").marcher;
         assert!(
@@ -685,6 +828,79 @@ C1  CIRCULAR  0.5  0  0  0
         ] {
             assert!(rpt.contains(needle), "report lacks {needle}");
         }
+    }
+
+    /// §12.3 for the surface: a mesh run checkpoints mid-run and a
+    /// restored session continues bit-identically to one never
+    /// interrupted — and the mesh fingerprint refuses a checkpoint from
+    /// a different terrain.
+    #[test]
+    fn a_mesh_run_resumes_bit_identically_from_a_checkpoint() {
+        let inp = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+START_DATE    06/01/2024
+START_TIME    00:00
+END_DATE      06/01/2024
+END_TIME      00:20
+ROUTING_STEP  5
+REPORT_STEP   0:05:00
+
+[JUNCTIONS]
+J1  100.0  2.0
+
+[OUTFALLS]
+O1  99.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.5  0  0  0
+";
+        // The uninterrupted reference.
+        let (mut whole, _, _) = crate::simulation::Simulation::open(inp).expect("open");
+        whole.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
+        whole.run();
+
+        // The same run, checkpointed midway and resumed elsewhere.
+        let (mut first, _, _) = crate::simulation::Simulation::open(inp).expect("open");
+        first.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
+        for _ in 0..120 {
+            first.step();
+        }
+        let mut held = Vec::new();
+        first.save_checkpoint(&mut held).expect("save");
+
+        let (mut resumed, _, _) = crate::simulation::Simulation::open(inp).expect("open");
+        resumed
+            .attach_overland(pond_mesh(0.3, "J1"))
+            .expect("attach");
+        resumed.load_checkpoint(&held).expect("load");
+        resumed.run();
+
+        let a = &whole.overland().expect("attached").marcher;
+        let b = &resumed.overland().expect("attached").marcher;
+        let bits = |v: &[f64]| v.iter().map(|x| x.to_bits()).collect::<Vec<_>>();
+        assert_eq!(bits(&a.vol), bits(&b.vol), "volumes");
+        assert_eq!(bits(&a.eta), bits(&b.eta), "surfaces");
+        assert_eq!(bits(&a.q), bits(&b.q), "discharges");
+        assert_eq!(a.coupling_out.to_bits(), b.coupling_out.to_bits(), "ledger");
+        assert_eq!(a.storage().to_bits(), b.storage().to_bits());
+        let ca = whole.overland().expect("attached");
+        let cb = resumed.overland().expect("attached");
+        assert_eq!(ca.delivered_in.to_bits(), cb.delivered_in.to_bits());
+
+        // A different terrain is a different model: the mesh
+        // fingerprint refuses.
+        let (mut other, _, _) = crate::simulation::Simulation::open(inp).expect("open");
+        let mut mesh = pond_mesh(0.3, "J1");
+        for v in &mut mesh.verts {
+            v.z += 0.5;
+        }
+        other.attach_overland(mesh).expect("attach");
+        let err = other.load_checkpoint(&held).expect_err("refusal");
+        assert!(err.contains("different mesh"), "{err}");
     }
 
     /// §15.6 the other direction: a surcharged node spills onto the

--- a/crates/engine-uds/src/simulation/coupled.rs
+++ b/crates/engine-uds/src/simulation/coupled.rs
@@ -45,6 +45,9 @@ pub struct CoupledSurface {
     /// ledger: surface drainage in, surface spill drawn back out (m³).
     pub delivered_in: f64,
     pub delivered_out: f64,
+    /// §14.16: per-point exchanged volume since the last reporting
+    /// instant (m³).
+    report_exchange: Vec<f64>,
 }
 
 impl CoupledSurface {
@@ -93,6 +96,7 @@ impl CoupledSurface {
             outfall_pending,
             delivered_in: 0.0,
             delivered_out: 0.0,
+            report_exchange: Vec::new(),
         })
     }
 
@@ -186,9 +190,13 @@ impl CoupledSurface {
                 .set_node_drive(slot, invert + y, y, rim, router.vertex_volume_now(vi));
         }
         self.marcher.advance(period);
+        if self.report_exchange.len() != self.marcher.exchanged().len() {
+            self.report_exchange = vec![0.0; self.marcher.exchanged().len()];
+        }
         for (k, &dv) in self.marcher.exchanged().iter().enumerate() {
             let slot = self.marcher.coupling_points()[k].node_slot as usize;
             self.pending[slot] += dv;
+            self.report_exchange[k] += dv;
         }
         // Damping for the coming period, §6.4: the summed conductance of
         // every point naming the vertex, against the live surface.
@@ -226,6 +234,18 @@ impl CoupledSurface {
         }
         // The surface the network sees next period.
         self.set_outfall_tailwaters(router);
+    }
+
+    /// §14.16: the per-point exchanged volumes since the last take
+    /// (m³); taking resets the accumulator.
+    pub fn take_report_exchange(&mut self) -> Vec<f64> {
+        if self.report_exchange.is_empty() {
+            self.report_exchange = vec![0.0; self.marcher.coupling_points().len()];
+        }
+        std::mem::replace(
+            &mut self.report_exchange,
+            vec![0.0; self.marcher.coupling_points().len()],
+        )
     }
 }
 
@@ -481,7 +501,7 @@ C1  CIRCULAR  0.5  0  0  0
 ";
         let (mut sim, _, findings) = crate::simulation::Simulation::open(inp).expect("open");
         assert!(findings.iter().all(|f| !f.kind.is_error()));
-        sim.attach_overland(&pond_mesh(0.3, "J1")).expect("attach");
+        sim.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
         let v0 = sim.overland().expect("attached").marcher.storage();
 
         // §15.10: a mesh run refuses checkpointing, by name.
@@ -500,6 +520,95 @@ C1  CIRCULAR  0.5  0  0  0
             (v0 - m.storage() - (m.coupling_out - m.coupling_in)).abs() < 1e-9,
             "surface ledger"
         );
+    }
+
+    /// §14.16 round trip through a live session: the sidecar streams at
+    /// the reporting instants, the reader validates and serves it back,
+    /// and the §14.9 report carries the overland blocks.
+    #[test]
+    fn the_overland_results_stream_round_trips() {
+        let inp = "\
+[OPTIONS]
+FLOW_UNITS    CMS
+START_DATE    06/01/2024
+START_TIME    00:00
+END_DATE      06/01/2024
+END_TIME      00:20
+ROUTING_STEP  5
+REPORT_STEP   0:05:00
+
+[JUNCTIONS]
+J1  100.0  2.0
+
+[OUTFALLS]
+O1  99.0  FREE
+
+[CONDUITS]
+C1  J1  O1  100  0.013  0  0
+
+[XSECTIONS]
+C1  CIRCULAR  0.5  0  0  0
+";
+        let (mut sim, _, _) = crate::simulation::Simulation::open(inp).expect("open");
+        sim.attach_overland(pond_mesh(0.3, "J1")).expect("attach");
+
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "hydra-uds-overland-{}-{}.h2o",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        ));
+        let sink = Box::new(std::fs::File::create(&path).expect("create"));
+        sim.begin_overland_results(sink).expect("begin");
+        sim.run();
+        sim.finish_results().expect("finish");
+
+        let r = crate::io::out_reader::OverlandResults::open(&path).expect("open results");
+        assert_eq!(r.periods, 4, "20 min at 5-min reporting");
+        assert_eq!(r.cells.len(), 32);
+        assert_eq!(r.verts.len(), 25);
+        assert_eq!(r.point_cells, [0]);
+        assert!((r.report_step - 300.0).abs() < 1e-9);
+        // The pond drains across the records: depth at the coupled cell
+        // falls, the exchange rate is a drain, the ledger closes.
+        let first = r.record(0).expect("first");
+        let last = r.record(3).expect("last");
+        assert!(last.t > first.t);
+        assert!(
+            f64::from(last.cells[0][0]) < f64::from(first.cells[0][0]),
+            "depth must fall as the pond drains"
+        );
+        assert!(first.exchange[0] > 0.0, "the point drains into the node");
+        assert!(last.ledger.junction_out > 0.0);
+        assert!(last.ledger.error.abs() < 1e-6, "ledger closes");
+        // A cell series is the records' own values re-cut.
+        let series = r.cell_series(0).expect("series");
+        assert_eq!(series.len(), 4);
+        assert_eq!(series[0].1, first.cells[0]);
+        assert_eq!(series[3].1, last.cells[0]);
+        // A torso without its epilog is refused as unfinished.
+        let bytes = std::fs::read(&path).expect("read");
+        std::fs::write(&path, &bytes[..bytes.len() - 8]).expect("truncate");
+        let err = crate::io::out_reader::OverlandResults::open(&path).unwrap_err();
+        assert!(err.contains("did not finish"), "{err}");
+        std::fs::remove_file(&path).ok();
+
+        // §14.9: the report carries the overland blocks and the §15.8
+        // named pair.
+        let mut rpt = Vec::new();
+        sim.write_report(&mut rpt).expect("report");
+        let rpt = String::from_utf8(rpt).expect("utf8");
+        for needle in [
+            "Overland Flow Continuity",
+            "Junction Drainage",
+            "Surface Drainage",
+            "Surface Spill",
+            "Overland Time Step Summary",
+            "Peak Active Cells",
+        ] {
+            assert!(rpt.contains(needle), "report lacks {needle}");
+        }
     }
 
     /// §15.6 the other direction: a surcharged node spills onto the

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -338,6 +338,19 @@ pub struct Simulation {
     series_warned: Vec<bool>,
     /// Per-vertex lateral overrides (§12.4 boundary forcing).
     lateral_override: HashMap<usize, f64>,
+    /// §15.6: the coupled overland surface, present only when a mesh
+    /// model is served.
+    coupled: Option<super::coupled::CoupledSurface>,
+    /// §15.7 precomputed rain weights and the model's rainfall mode.
+    overland_rain: crate::overland::meteorology::RainWeights,
+    overland_rain_mode: crate::overland::RainfallMode,
+    /// §15.6 `COUPLING_SYNC` batching: authored batch width (s) and the
+    /// surface time accrued toward the next batch.
+    overland_sync: f64,
+    overland_accrued: f64,
+    /// §15.5 driven boundary slots: (marcher boundary, series index,
+    /// stage?), resolved once at attach.
+    overland_driven: Vec<(usize, usize, bool)>,
     /// §12.4: injected outfall stages and link settings, held so a rule
     /// cannot move an element a caller has taken over, and so a restored
     /// checkpoint takes it over again.
@@ -809,6 +822,12 @@ impl Simulation {
                 link_by_id,
                 series_warned: vec![false; n_series],
                 lateral_override: HashMap::new(),
+                coupled: None,
+                overland_rain: Default::default(),
+                overland_rain_mode: crate::overland::RainfallMode::None,
+                overland_sync: 0.0,
+                overland_accrued: 0.0,
+                overland_driven: Vec::new(),
                 stage_override: HashMap::new(),
                 setting_override: HashMap::new(),
                 loss_override: HashMap::new(),
@@ -1838,6 +1857,112 @@ impl Simulation {
     /// period's start, update dynamic boundaries, route — or freeze,
     /// between events — and service any reporting boundary passed.
     /// Returns false once the run is complete.
+    /// §15.6: attach a validated overland mesh, resolving its coupled
+    /// nodes against the network and precomputing the §15.7 rain
+    /// weights. Serving is gated by `open` (§1.8); this is the wiring
+    /// that gate will open onto.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the §1.8 serving gate's wiring")
+    )]
+    pub(crate) fn attach_overland(
+        &mut self,
+        mesh: &crate::overland::OverlandMesh,
+    ) -> Result<(), super::coupled::AttachError> {
+        let topo =
+            crate::overland::Topology::build(mesh).map_err(super::coupled::AttachError::Mesh)?;
+        let marcher = crate::overland::marcher::Marcher::build(mesh, &topo);
+        let cs = super::coupled::CoupledSurface::new(marcher, &self.net, &mut self.router)
+            .map_err(|e| super::coupled::AttachError::UnknownNode(e.node))?;
+        let positions: Vec<Option<(f64, f64)>> =
+            self.net.gages.iter().map(|g| g.position).collect();
+        let cx: Vec<f64> = topo.centroid.iter().map(|c| c[0]).collect();
+        let cy: Vec<f64> = topo.centroid.iter().map(|c| c[1]).collect();
+        self.overland_rain = crate::overland::meteorology::RainWeights::build(&cx, &cy, &positions);
+        self.overland_rain_mode = mesh.options.rainfall_mode;
+        self.overland_sync = mesh.options.coupling_sync;
+        // §15.5: driven boundary parameters resolve here, by name, once.
+        self.overland_driven.clear();
+        let mut cs = cs;
+        for d in cs.marcher.driven_boundaries().to_vec() {
+            let Some(si) = self.net.timeseries.iter().position(|t| t.id == d.series) else {
+                return Err(super::coupled::AttachError::UnknownSeries(d.series));
+            };
+            self.overland_driven.push((d.boundary, si, d.is_stage));
+        }
+        for (slot, name) in cs.marcher.rating_curve_names().to_vec().iter().enumerate() {
+            let Some(curve) = self.net.curves.iter().find(|c| &c.id == name) else {
+                return Err(super::coupled::AttachError::UnknownCurve(name.clone()));
+            };
+            cs.marcher.set_rating_curve(slot, curve.points.clone());
+        }
+        self.coupled = Some(cs);
+        Ok(())
+    }
+
+    /// §15.7: set the surface's rain and evaporation for the coming
+    /// co-advance from the model's gauges and climate.
+    fn drive_overland_sources(&mut self, cs: &mut super::coupled::CoupledSurface, t: f64) {
+        let epoch = self.start_epoch + t;
+        let month = self.calendar(t).0;
+        let rain_factor = self.net.climate.adjust_rainfall[(month - 1) as usize];
+        use crate::overland::RainfallMode;
+        match self.overland_rain_mode {
+            RainfallMode::None => {
+                for r in &mut cs.marcher.rain {
+                    *r = 0.0;
+                }
+            }
+            mode => {
+                let rates: Vec<f64> = (0..self.net.gages.len())
+                    .map(|g| {
+                        self.surface
+                            .as_ref()
+                            .map_or(0.0, |s| s.gage_rate(g, epoch) * rain_factor)
+                    })
+                    .collect();
+                // §15.7: NATURAL_NEIGHBOUR with no located gauge falls
+                // back to the SYSTEM mean.
+                if mode == RainfallMode::NaturalNeighbour && self.overland_rain.ready() {
+                    self.overland_rain.apply(&rates, &mut cs.marcher.rain);
+                } else {
+                    let mean = if rates.is_empty() {
+                        0.0
+                    } else {
+                        rates.iter().sum::<f64>() / rates.len() as f64
+                    };
+                    for r in &mut cs.marcher.rain {
+                        *r = mean;
+                    }
+                }
+            }
+        }
+        let evap = self.evaporation_rate(month);
+        for e in &mut cs.marcher.evap {
+            *e = evap;
+        }
+        // §15.5: series-driven stages and flows resolve to this
+        // advance's values.
+        for &(bi, si, is_stage) in &self.overland_driven {
+            let v = series_value_pure(&self.net, self.start_epoch, si, t, true);
+            if is_stage {
+                cs.marcher.set_boundary_stage(bi, v);
+            } else {
+                cs.marcher.set_boundary_flow(bi, v);
+            }
+        }
+    }
+
+    /// The attached overland surface, for the callers the §1.8 serving
+    /// gate will admit (and the crate's own tests today).
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the §1.8 serving gate's wiring")
+    )]
+    pub(crate) fn overland(&self) -> Option<&super::coupled::CoupledSurface> {
+        self.coupled.as_ref()
+    }
+
     pub fn step(&mut self) -> bool {
         let t = self.router.time();
         if t >= self.duration - 1e-9 {
@@ -1856,7 +1981,12 @@ impl Simulation {
             // §7.7: channels evaporate at the session's potential rate.
             let month = self.calendar(t).0;
             self.router.evap_rate = self.evaporation_rate(month);
-            let (base, base_mass) = self.assemble_lateral(t);
+            let (mut base, base_mass) = self.assemble_lateral(t);
+            // §15.6: last period's surface exchange delivers as this
+            // period's lateral inflow, a constant rate over the window.
+            if let Some(cs) = self.coupled.as_mut() {
+                cs.deliver_laterals(&mut base, period_end - t);
+            }
             self.vol_dwf += self.last_dwf_total * (period_end - t);
             self.vol_ext += self.last_ext_total * (period_end - t);
             // §10.1: hydrology outputs interpolate linearly to routing
@@ -1966,6 +2096,23 @@ impl Simulation {
             } else {
                 self.router.advance(period_end, &interp);
             }
+            // §15.6: the surface co-advances the interval the network
+            // just finished, batched by COUPLING_SYNC (clamped to the
+            // band from one routing period to 60 s), node grades frozen.
+            if let Some(mut cs) = self.coupled.take() {
+                self.overland_accrued += self.router.time() - t;
+                let sync = self
+                    .overland_sync
+                    .clamp(self.routing_period, 60.0_f64.max(self.routing_period));
+                if self.overland_accrued + 1e-9 >= sync {
+                    self.drive_overland_sources(&mut cs, t);
+                    let span = self.overland_accrued;
+                    cs.co_advance(&mut self.router, span);
+                    self.overland_accrued = 0.0;
+                }
+                self.coupled = Some(cs);
+            }
+
             // Retain the end-of-period laterals for the §14.9 records —
             // §7.8 inlet transfers included, or an inlet-fed vertex would
             // report zero inflow while its depth rises.
@@ -2895,6 +3042,15 @@ impl Simulation {
             next_rule_t,
             series_warned,
             lateral_override,
+            coupled,
+            // §15.6 parameters, rebuilt when a mesh is attached; the
+            // accrued batch time is nonzero only when `coupled` is, and
+            // the mesh refusal below covers it.
+            overland_rain: _,
+            overland_rain_mode: _,
+            overland_sync: _,
+            overland_accrued: _,
+            overland_driven: _,
             stage_override,
             setting_override,
             loss_override,
@@ -2927,6 +3083,14 @@ impl Simulation {
             snapshots,
             notices,
         } = self;
+        // §15.10: mesh-run checkpoint carriage is a recorded deferral —
+        // the surface state (cell volumes, face discharges, exchange
+        // bookkeeping) is not yet carried, and restoring it from a
+        // fresh mesh would continue plausibly and wrongly.
+        if coupled.is_some() {
+            return Err("this model couples an overland mesh (section 15), whose state a                         checkpoint does not yet carry"
+                .into());
+        }
         let io = |e: std::io::Error| e.to_string();
         w.write_all(cp::STAMP).map_err(io)?;
         w.write_all(&cp::VERSION.to_le_bytes()).map_err(io)?;

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -351,6 +351,9 @@ pub struct Simulation {
     /// §15.5 driven boundary slots: (marcher boundary, series index,
     /// stage?), resolved once at attach.
     overland_driven: Vec<(usize, usize, bool)>,
+    /// §14.16: the overland results stream, when a sink is attached.
+    overland_out: Option<crate::io::overland_out::OverlandStream<Box<dyn std::io::Write + Send>>>,
+    overland_out_error: Option<std::io::Error>,
     /// §12.4: injected outfall stages and link settings, held so a rule
     /// cannot move an element a caller has taken over, and so a restored
     /// checkpoint takes it over again.
@@ -828,6 +831,8 @@ impl Simulation {
                 overland_sync: 0.0,
                 overland_accrued: 0.0,
                 overland_driven: Vec::new(),
+                overland_out: None,
+                overland_out_error: None,
                 stage_override: HashMap::new(),
                 setting_override: HashMap::new(),
                 loss_override: HashMap::new(),
@@ -1867,11 +1872,11 @@ impl Simulation {
     )]
     pub(crate) fn attach_overland(
         &mut self,
-        mesh: &crate::overland::OverlandMesh,
+        mesh: crate::overland::OverlandMesh,
     ) -> Result<(), super::coupled::AttachError> {
         let topo =
-            crate::overland::Topology::build(mesh).map_err(super::coupled::AttachError::Mesh)?;
-        let marcher = crate::overland::marcher::Marcher::build(mesh, &topo);
+            crate::overland::Topology::build(&mesh).map_err(super::coupled::AttachError::Mesh)?;
+        let marcher = crate::overland::marcher::Marcher::build(&mesh, &topo);
         let cs = super::coupled::CoupledSurface::new(marcher, &self.net, &mut self.router)
             .map_err(|e| super::coupled::AttachError::UnknownNode(e.node))?;
         let positions: Vec<Option<(f64, f64)>> =
@@ -1897,6 +1902,36 @@ impl Simulation {
             cs.marcher.set_rating_curve(slot, curve.points.clone());
         }
         self.coupled = Some(cs);
+        // The mesh is the model's; the §14.16 stream reads its geometry.
+        self.net.overland = Some(mesh);
+        Ok(())
+    }
+
+    /// §14.16: stream the overland results to `sink` as the run
+    /// produces them, alongside the §14.9 stream. Attach after the
+    /// mesh and before stepping; refused without a mesh.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the §1.8 serving gate's wiring")
+    )]
+    pub(crate) fn begin_overland_results(
+        &mut self,
+        sink: Box<dyn std::io::Write + Send>,
+    ) -> std::io::Result<()> {
+        let (Some(mesh), Some(cs)) = (self.net.overland.as_ref(), self.coupled.as_ref()) else {
+            return Err(std::io::Error::other(
+                "this run has no overland mesh to record",
+            ));
+        };
+        let out = crate::io::overland_out::OverlandStream::begin(
+            sink,
+            mesh,
+            &cs.marcher,
+            self.start_epoch,
+            self.report_step,
+            self.next_report,
+        )?;
+        self.overland_out = Some(out);
         Ok(())
     }
 
@@ -2179,6 +2214,14 @@ impl Simulation {
             // instants alone, which is what a reader finds in the
             // results file.
             self.router.record_reported_depths();
+            // §14.16: the overland record rides the same instants.
+            if let (Some(cs), Some(out)) = (self.coupled.as_mut(), self.overland_out.as_mut()) {
+                let vols = cs.take_report_exchange();
+                let rates: Vec<f64> = vols.iter().map(|v| v / self.report_step).collect();
+                if let Err(e) = out.append(self.next_report, &cs.marcher, &rates) {
+                    self.overland_out_error.get_or_insert(e);
+                }
+            }
             self.next_report += self.report_step;
         }
         true
@@ -3051,6 +3094,10 @@ impl Simulation {
             overland_sync: _,
             overland_accrued: _,
             overland_driven: _,
+            // §14.16 stream state: possible only on a coupled run, and
+            // the mesh refusal above covers those.
+            overland_out: _,
+            overland_out_error: _,
             stage_override,
             setting_override,
             loss_override,
@@ -4060,6 +4107,16 @@ impl Simulation {
         crate::io::rpt_writer::write_rpt(
             &crate::io::rpt_writer::ReportInputs {
                 net: &self.net,
+                overland: self
+                    .coupled
+                    .as_ref()
+                    .map(|cs| crate::io::rpt_writer::OverlandRpt {
+                        ledger: crate::io::overland_out::LedgerRow::of(&cs.marcher),
+                        initial_storage: cs.marcher.initial_storage(),
+                        delivered_in: cs.delivered_in,
+                        delivered_out: cs.delivered_out,
+                        march: cs.marcher.statistics(),
+                    }),
                 surface,
                 subsurface,
                 flow,
@@ -4149,6 +4206,14 @@ impl Simulation {
         if let Some(e) = self.out_error.take() {
             self.out = None;
             return Err(e);
+        }
+        if let Some(e) = self.overland_out_error.take() {
+            self.overland_out = None;
+            self.out = None;
+            return Err(e);
+        }
+        if let Some(ov) = self.overland_out.take() {
+            ov.finish()?;
         }
         match self.out.take() {
             Some(out) => out.finish().map(|_| ()),

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -3098,16 +3098,15 @@ impl Simulation {
             series_warned,
             lateral_override,
             coupled,
-            // §15.6 parameters, rebuilt when a mesh is attached; the
-            // accrued batch time is nonzero only when `coupled` is, and
-            // the mesh refusal below covers it.
+            // §15.6 parameters, rebuilt when a mesh is attached.
             overland_rain: _,
             overland_rain_mode: _,
             overland_sync: _,
-            overland_accrued: _,
+            overland_accrued,
             overland_driven: _,
-            // §14.16 stream state: possible only on a coupled run, and
-            // the mesh refusal above covers those.
+            // §12.3: the sidecar is a stream, not held state — a
+            // resumed run's sidecar begins at the resume instant and
+            // its header says so.
             overland_out: _,
             overland_out_error: _,
             stage_override,
@@ -3142,14 +3141,6 @@ impl Simulation {
             snapshots,
             notices,
         } = self;
-        // §15.10: mesh-run checkpoint carriage is a recorded deferral —
-        // the surface state (cell volumes, face discharges, exchange
-        // bookkeeping) is not yet carried, and restoring it from a
-        // fresh mesh would continue plausibly and wrongly.
-        if coupled.is_some() {
-            return Err("this model couples an overland mesh (section 15), whose state a                         checkpoint does not yet carry"
-                .into());
-        }
         let io = |e: std::io::Error| e.to_string();
         w.write_all(cp::STAMP).map_err(io)?;
         w.write_all(&cp::VERSION.to_le_bytes()).map_err(io)?;
@@ -3367,7 +3358,38 @@ impl Simulation {
             gw.checkpoint_put(w).map_err(io)?;
         }
         router.checkpoint_put(w).map_err(io)?;
+        // §12.3: the overland surface, behind its own mesh fingerprint —
+        // the model fingerprint does not see the mesh.
+        cp::put_b(w, coupled.is_some()).map_err(io)?;
+        if let Some(cs) = coupled {
+            cp::put_u(w, self.overland_fingerprint()).map_err(io)?;
+            cs.checkpoint_put(w).map_err(io)?;
+            cp::put_f(w, *overland_accrued).map_err(io)?;
+        }
         Ok(())
+    }
+
+    /// §12.3: a fingerprint of the overland mesh — vertex coordinates
+    /// and cell definitions in model order. The model fingerprint does
+    /// not see the mesh, and a checkpoint restored onto a different
+    /// terrain would put every volume on the wrong cell.
+    fn overland_fingerprint(&self) -> u64 {
+        let mut h = crate::simulation::checkpoint::Fnv::new();
+        if let Some(mesh) = &self.net.overland {
+            h.write(&(mesh.verts.len() as u64).to_le_bytes());
+            h.write(&(mesh.cells.len() as u64).to_le_bytes());
+            for v in &mesh.verts {
+                for c in [v.x, v.y, v.z] {
+                    h.write(&c.to_le_bytes());
+                }
+            }
+            for c in &mesh.cells {
+                for i in c.v {
+                    h.write(&i.to_le_bytes());
+                }
+            }
+        }
+        h.finish()
     }
 
     /// Restore a checkpoint over this session (§12.3).
@@ -3708,6 +3730,32 @@ impl Simulation {
             gw.checkpoint_get(&mut r)?;
         }
         self.router.checkpoint_get(&mut r)?;
+        // §12.3: the overland surface. A mesh checkpoint into a
+        // meshless session (or the reverse) is a different model, even
+        // when the network half fingerprints alike.
+        let has_overland = r.b()?;
+        if has_overland != self.coupled.is_some() {
+            return Err(if has_overland {
+                "this checkpoint carries an overland surface and this model has none".into()
+            } else {
+                "this model couples an overland mesh and this checkpoint carries none".into()
+            });
+        }
+        if has_overland {
+            let fp = r.u()?;
+            if fp != self.overland_fingerprint() {
+                return Err(
+                    "this checkpoint's overland surface came from a different mesh (§12.3)".into(),
+                );
+            }
+            let mut cs = self.coupled.take().expect("checked above");
+            // On error `cs` drops here, leaving no coupled surface — a
+            // half-restored one must not march.
+            cs.checkpoint_get(&mut r)?;
+            cs.resync_network(&mut self.router);
+            self.coupled = Some(cs);
+            self.overland_accrued = r.f()?;
+        }
         // Bytes left over mean a layout this build does not share, which
         // the version alone did not catch.
         if !r.at_end() {

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -497,7 +497,7 @@ impl Simulation {
             .into_iter()
             .map(|(name, readings)| (name, crate::io::rain::RainRecords::Station(readings)))
             .collect();
-        Simulation::open_inner(input, climate_records, records, None)
+        Simulation::open_inner(input, climate_records, records, None, None)
     }
 
     /// Load a model together with rain files in whichever layout each was
@@ -509,7 +509,7 @@ impl Simulation {
         climate_records: Vec<crate::model::DailyClimate>,
         rain_files: Vec<(String, crate::io::rain::RainRecords)>,
     ) -> Result<(Simulation, Vec<Diagnostic>, Vec<ValidationDiagnostic>), OpenError> {
-        Simulation::open_inner(input, climate_records, rain_files, None)
+        Simulation::open_inner(input, climate_records, rain_files, None, None)
     }
 
     /// Load a model whose file-sourced gages read a rainfall interface
@@ -526,7 +526,19 @@ impl Simulation {
     ) -> Result<(Simulation, Vec<Diagnostic>, Vec<ValidationDiagnostic>), OpenError> {
         let iface = crate::io::iface::parse_rain_iface(rain_interface)
             .map_err(|e| OpenError::Transport(format!("rainfall interface file: {e}")))?;
-        Simulation::open_inner(input, climate_records, Vec::new(), Some(iface))
+        Simulation::open_inner(input, climate_records, Vec::new(), Some(iface), None)
+    }
+
+    /// Load a model together with the external mesh file its
+    /// `[2D_MESH_FILE]` declares (§14.15) — the caller owns reading it,
+    /// like every auxiliary. The external file's sections continue the
+    /// model's own: its vertices and cells extend the inline numbering,
+    /// and either file's SI header governs the whole mesh.
+    pub fn open_with_overland_mesh(
+        input: &str,
+        mesh_text: &str,
+    ) -> Result<(Simulation, Vec<Diagnostic>, Vec<ValidationDiagnostic>), OpenError> {
+        Simulation::open_inner(input, Vec::new(), Vec::new(), None, Some(mesh_text))
     }
 
     fn open_inner(
@@ -534,11 +546,47 @@ impl Simulation {
         climate_records: Vec<crate::model::DailyClimate>,
         rain_files: Vec<(String, crate::io::rain::RainRecords)>,
         rain_interface: Option<crate::io::iface::RainInterface>,
+        overland_mesh: Option<&str>,
     ) -> Result<(Simulation, Vec<Diagnostic>, Vec<ValidationDiagnostic>), OpenError> {
-        let (mut net, diags) = parse_network(input);
+        let (mut net, mut diags) = parse_network(input);
         if diags.iter().any(|d| d.kind.is_error()) {
             return Err(OpenError::Parse(diags));
         }
+        // §14.15: a declared external mesh file carries the mesh's own
+        // sections; supplied, they continue the inline ones — indices,
+        // units header and all — through one combined parse. Declared
+        // and not supplied, the mesh cannot be read: under IGNORE_2D
+        // the run warns and proceeds without it, and otherwise the
+        // refusals below name what is missing.
+        let mesh_file = net.overland.as_ref().and_then(|m| m.mesh_file.clone());
+        match (&mesh_file, overland_mesh) {
+            (Some(_), Some(external)) => {
+                net.overland = crate::io::overland::reparse_with_external(
+                    input,
+                    external,
+                    &net.options,
+                    &mut diags,
+                );
+            }
+            (Some(name), None) if net.options.ignore_overland => {
+                // The 1D half runs, but the author should hear that the
+                // unreadable mesh was dropped, file named.
+                diags.push(Diagnostic {
+                    line: 0,
+                    kind: crate::io::survey::DiagnosticKind::UnknownOverlandOption {
+                        key: format!("mesh file {name:?} not supplied; mesh ignored"),
+                    },
+                });
+                net.overland = None;
+            }
+            (Some(name), None) => {
+                return Err(OpenError::Overland(format!(
+                    "this model reads its mesh from {name:?}, which was not                      supplied (§14.15)"
+                )));
+            }
+            (None, _) => {}
+        }
+
         // §1.8: the overland sections are specified (§15) and not yet
         // served. A mesh model refuses with the campaign named rather
         // than silently running its one-dimensional half; `IGNORE_2D

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -51,6 +51,10 @@ pub enum OpenError {
     Controls(String),
     /// A transport configuration this stage does not evaluate yet (§8).
     Transport(String),
+    /// The model authors an overland mesh (§15), which is specified and
+    /// not yet served (§1.8). `IGNORE_2D YES` runs the model
+    /// one-dimensional in the meantime.
+    Overland(String),
 }
 
 /// One readable line per refusal, so applications can show the error
@@ -93,7 +97,9 @@ impl std::fmt::Display for OpenError {
             }
             OpenError::Routing(r) => write!(f, "{r}"),
             OpenError::Surface(s) => write!(f, "{s}"),
-            OpenError::Controls(msg) | OpenError::Transport(msg) => f.write_str(msg),
+            OpenError::Controls(msg) | OpenError::Transport(msg) | OpenError::Overland(msg) => {
+                f.write_str(msg)
+            }
         }
     }
 }
@@ -532,6 +538,30 @@ impl Simulation {
         let (mut net, diags) = parse_network(input);
         if diags.iter().any(|d| d.kind.is_error()) {
             return Err(OpenError::Parse(diags));
+        }
+        // §1.8: the overland sections are specified (§15) and not yet
+        // served. A mesh model refuses with the campaign named rather
+        // than silently running its one-dimensional half; `IGNORE_2D
+        // YES` is the author's own request for exactly that half, so it
+        // proceeds, dropping the mesh from the run.
+        if let Some(mesh) = &net.overland {
+            if net.options.ignore_overland {
+                // Validated even when ignored: an authoring defect in a
+                // preserved mesh should be heard now, not on the day the
+                // author flips the option off.
+                if let Err(errors) = crate::overland::Topology::build(mesh) {
+                    return Err(OpenError::Overland(format!(
+                        "the ignored mesh is defective: {}",
+                        errors.first().map(|e| e.to_string()).unwrap_or_default()
+                    )));
+                }
+                net.overland = None;
+            } else {
+                return Err(OpenError::Overland(
+                    "this model authors a two-dimensional mesh; overland flow                      (§15) is specified and not yet served. Set IGNORE_2D YES                      to run the one-dimensional model"
+                        .to_string(),
+                ));
+            }
         }
         // Before validation, not after: §3.1 says a realised record is
         // treated exactly as if its series had been written in the model,

--- a/crates/engine-uds/src/simulation/engine.rs
+++ b/crates/engine-uds/src/simulation/engine.rs
@@ -51,9 +51,9 @@ pub enum OpenError {
     Controls(String),
     /// A transport configuration this stage does not evaluate yet (§8).
     Transport(String),
-    /// The model authors an overland mesh (§15), which is specified and
-    /// not yet served (§1.8). `IGNORE_2D YES` runs the model
-    /// one-dimensional in the meantime.
+    /// The model's overland mesh (§15) was refused: a §15.2 validation
+    /// defect, or a coupling row naming a node, series or curve the
+    /// model does not have (§15.6).
     Overland(String),
 }
 
@@ -620,12 +620,9 @@ impl Simulation {
                     )));
                 }
                 net.overland = None;
-            } else {
-                return Err(OpenError::Overland(
-                    "this model authors a two-dimensional mesh; overland flow                      (§15) is specified and not yet served. Set IGNORE_2D YES                      to run the one-dimensional model"
-                        .to_string(),
-                ));
             }
+            // Served (§1.8): the mesh attaches to the session below,
+            // once the router it couples to exists.
         }
         // Before validation, not after: §3.1 says a realised record is
         // treated exactly as if its series had been written in the model,
@@ -805,7 +802,7 @@ impl Simulation {
         let _ = &mut notices;
 
         let nv = net.vertices.len();
-        Ok((
+        let mut sim = (
             Simulation {
                 router,
                 surface,
@@ -906,7 +903,28 @@ impl Simulation {
             },
             diags,
             findings,
-        ))
+        );
+        // §1.8: serve §15 — attach the model's mesh to the session it
+        // couples to.
+        if let Some(mesh) = sim.0.net.overland.take() {
+            use super::coupled::AttachError;
+            sim.0.attach_overland(mesh).map_err(|e| match e {
+                AttachError::Mesh(errors) => OpenError::Overland(format!(
+                    "the mesh is defective: {}",
+                    errors.first().map(|d| d.to_string()).unwrap_or_default()
+                )),
+                AttachError::UnknownNode(n) => OpenError::Overland(format!(
+                    "a coupling row names the node {n:?}, which this model does not have"
+                )),
+                AttachError::UnknownSeries(n) => OpenError::Overland(format!(
+                    "a boundary row names the time series {n:?}, which this model does not have"
+                )),
+                AttachError::UnknownCurve(n) => OpenError::Overland(format!(
+                    "a boundary row names the curve {n:?}, which this model does not have"
+                )),
+            })?;
+        }
+        Ok(sim)
     }
 
     /// Current simulation time (s from start).
@@ -1866,10 +1884,6 @@ impl Simulation {
     /// nodes against the network and precomputing the §15.7 rain
     /// weights. Serving is gated by `open` (§1.8); this is the wiring
     /// that gate will open onto.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the §1.8 serving gate's wiring")
-    )]
     pub(crate) fn attach_overland(
         &mut self,
         mesh: crate::overland::OverlandMesh,
@@ -1909,12 +1923,8 @@ impl Simulation {
 
     /// §14.16: stream the overland results to `sink` as the run
     /// produces them, alongside the §14.9 stream. Attach after the
-    /// mesh and before stepping; refused without a mesh.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the §1.8 serving gate's wiring")
-    )]
-    pub(crate) fn begin_overland_results(
+    /// mesh and before stepping; refused for a model with no mesh.
+    pub fn begin_overland_results(
         &mut self,
         sink: Box<dyn std::io::Write + Send>,
     ) -> std::io::Result<()> {
@@ -1988,12 +1998,14 @@ impl Simulation {
         }
     }
 
-    /// The attached overland surface, for the callers the §1.8 serving
-    /// gate will admit (and the crate's own tests today).
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the §1.8 serving gate's wiring")
-    )]
+    /// Whether this model carries an overland mesh (§15) — the caller's
+    /// cue to attach the §14.16 results stream.
+    pub fn has_overland(&self) -> bool {
+        self.coupled.is_some()
+    }
+
+    /// The attached overland surface, for the crate's own tests.
+    #[cfg(test)]
     pub(crate) fn overland(&self) -> Option<&super::coupled::CoupledSurface> {
         self.coupled.as_ref()
     }

--- a/crates/engine-uds/src/simulation/mod.rs
+++ b/crates/engine-uds/src/simulation/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod checkpoint;
 pub mod controls;
+pub mod coupled;
 pub mod expression;
 pub mod time;
 

--- a/crates/engine-uds/src/simulation/spec.md
+++ b/crates/engine-uds/src/simulation/spec.md
@@ -484,6 +484,7 @@ therefore also carries:
 | Position in supplied records | How far each supplied interface file has been read, and the day of the climate record in force |
 | Latches | Every warning issued at most once per run, so a restored run neither repeats one nor swallows one |
 | Output so far | The reporting snapshots and runtime notices already produced, and the interface-file records already collected |
+| Overland surface | For a §15 mesh run: cell volumes, prognostic face and boundary discharges, the pending face accumulators, the active set and tier assignment (hysteresis and cadence are history, not derivable from depths), the lazy-source clock, the §15.8 ledger and march counters, and the §15.6 exchange bookkeeping — pending deliveries, banked outfall injection, delivered totals, per-point report accumulation, and the batch time accrued toward `COUPLING_SYNC` |
 
 The last of those is what makes a checkpoint large: a restored run must be
 able to write the whole run's results, not the part after the checkpoint.
@@ -507,7 +508,12 @@ is the whole of what it promises, and a checkpoint converted to a model's
 display units would restore something subtly other than what it saved.
 
 The fingerprint is the counts of parcels, vertices, channels, constituents
-and land uses, and a hash of every element identifier in model order. Counts
+and land uses, and a hash of every element identifier in model order. A
+mesh run's overland section carries its own fingerprint besides — the
+mesh's vertex coordinates and cell definitions hashed in model order —
+because the model fingerprint does not see the mesh, and a checkpoint
+restored onto a different terrain would put every volume on the wrong
+cell. Counts
 alone let a checkpoint load into a model with the same shape and different
 elements, and let a reordered model load a checkpoint whose every value then
 belongs to the wrong element. Hashing the identifiers costs one pass and
@@ -522,6 +528,15 @@ refuses both.
 >
 > *Source: `hotstart.c:20–25`, and `openHotstartFile2` which compares five
 > counts and `UnitSystem`.*
+
+**The §14.16 sidecar is a stream, not held state.** The reporting
+snapshots a checkpoint carries rebuild the whole §14.9 results file, but
+overland records are written to their sidecar as produced and never
+retained — at mesh scale, holding them would multiply the checkpoint's
+size by the surface. A resumed run's sidecar therefore begins at the
+resume instant, and says so itself: its header's first-instant field is
+the resume's first reporting instant. A reader wanting the whole run
+reads both files.
 
 **Supplied files are not in the checkpoint, and are checked against it.**
 An interface file's contents belong to the caller, who read them and handed

--- a/crates/engine-uds/src/spec.md
+++ b/crates/engine-uds/src/spec.md
@@ -293,10 +293,11 @@ needing one is refused with a named reason. A section absent from
 the specification remains unspecified behaviour rather than deferred
 behaviour — it is not implemented until it is specified.
 
-One section runs ahead of its implementation: **§15 (overland flow) is
-specified and not yet served.** Until its implementation lands, a model
-carrying two-dimensional sections receives §14.2's unrecognised-section
-treatment — the sections are reported and discarded, and the run is the
-one-dimensional model's. Serving §15 is the campaign the specification
-exists to govern; every other section this specification describes is
-served.
+Every section this specification describes is served, **§15 (overland
+flow) included**: a model carrying two-dimensional sections is
+validated (§15.2), coupled (§15.6) and marched (§15.4) with the run,
+its results streamed per §14.16 and its balances reported per §14.9.
+`IGNORE_2D YES` remains the author's explicit request to run the
+one-dimensional model alone; the mesh is still validated so an
+authoring defect is heard now, not on the day the option flips off.
+The capabilities §15.10 records as deferred stay typed refusals.

--- a/crates/engine-uds/src/spec.md
+++ b/crates/engine-uds/src/spec.md
@@ -223,6 +223,7 @@ Each document owns a disjoint, contiguous range:
 | 9–12 | Simulation | Operational control; time integration and coupling; conservation; session interface |
 | 13 | Analysis | Post-simulation analytics |
 | 14 | Interoperability | Predecessor file formats, import, and export |
+| 15 | Overland | Two-dimensional surface flow and its network coupling |
 
 The ordering is deliberate. The physics is specified first, on its own terms;
 interoperability is specified last, as an adapter between the predecessor's
@@ -288,7 +289,14 @@ orchestration (§10), accounting and statistics (§11), the session (§12), and
 interoperability (§14).
 
 Deferred capabilities are typed refusals, never approximations: a model
-needing one is refused with a named reason. Nothing is deferred: every
-capability this specification describes is served. A section absent from
+needing one is refused with a named reason. A section absent from
 the specification remains unspecified behaviour rather than deferred
 behaviour — it is not implemented until it is specified.
+
+One section runs ahead of its implementation: **§15 (overland flow) is
+specified and not yet served.** Until its implementation lands, a model
+carrying two-dimensional sections receives §14.2's unrecognised-section
+treatment — the sections are reported and discarded, and the run is the
+one-dimensional model's. Serving §15 is the campaign the specification
+exists to govern; every other section this specification describes is
+served.

--- a/crates/engine-uds/tests/session.rs
+++ b/crates/engine-uds/tests/session.rs
@@ -6579,11 +6579,11 @@ VA J1
 ";
 
     // Supplied: the coupling row in the model resolves against a vertex
-    // the external file authors, and the refusal is the not-served one.
-    let Err(err) = Simulation::open_with_overland_mesh(model, external) else {
-        panic!("mesh models refuse until served");
-    };
-    assert!(err.to_string().contains("IGNORE_2D"), "{err}");
+    // the external file authors, and the coupled model runs (§1.8).
+    let (mut sim, diags, _) =
+        Simulation::open_with_overland_mesh(model, external).expect("the coupled model serves");
+    assert!(diags.iter().all(|d| !d.kind.is_error()));
+    sim.run();
 
     // Not supplied: the refusal names the file instead.
     let Err(err) = Simulation::open(model) else {
@@ -6602,12 +6602,12 @@ IGNORE_2D YES",
     sim.run();
 }
 
-/// §1.8: a mesh model refuses with the campaign named; `IGNORE_2D YES`
-/// runs its one-dimensional half; and an ignored mesh is still
-/// validated, so an authoring defect is heard now rather than on the
-/// day the option flips off.
+/// §1.8: a mesh model is served — it opens and marches with the run —
+/// while `IGNORE_2D YES` still runs the one-dimensional half alone,
+/// and the mesh is validated either way, so an authoring defect is
+/// heard now rather than on the day the option flips off.
 #[test]
-fn a_mesh_model_refuses_until_overland_is_served() {
+fn a_mesh_model_is_served() {
     let base = "[OPTIONS]\nFLOW_UNITS CMS\nROUTING_STEP 5\n\
         END_TIME 00:10:00\n{IGNORE}\n\
         [JUNCTIONS]\nJ1 10 4 0 0 0\n[OUTFALLS]\nO1 9 FREE NO\n\
@@ -6616,12 +6616,10 @@ fn a_mesh_model_refuses_until_overland_is_served() {
         [2D_VERTICES]\n0 0 10\n1 0 10\n0 1 10\n\
         [2D_TRIANGLES]\n0 1 2 {N}\n";
 
-    let refused = base.replace("{IGNORE}", "").replace("{N}", "0.02");
-    let Err(err) = Simulation::open(&refused) else {
-        panic!("mesh models refuse");
-    };
-    let msg = err.to_string();
-    assert!(msg.contains("IGNORE_2D"), "{msg}");
+    let served = base.replace("{IGNORE}", "").replace("{N}", "0.02");
+    let (mut sim, diags, _) = Simulation::open(&served).expect("mesh models serve");
+    assert!(diags.iter().all(|d| !d.kind.is_error()));
+    sim.run();
 
     let ignored = base
         .replace("{IGNORE}", "IGNORE_2D YES")
@@ -6630,11 +6628,11 @@ fn a_mesh_model_refuses_until_overland_is_served() {
     assert!(diags.iter().all(|d| !d.kind.is_error()));
     sim.run();
 
-    let defective = base
-        .replace("{IGNORE}", "IGNORE_2D YES")
-        .replace("{N}", "0");
-    let Err(err) = Simulation::open(&defective) else {
-        panic!("defects are heard even ignored");
-    };
-    assert!(err.to_string().contains("Manning"), "{err}");
+    for ignore in ["IGNORE_2D YES", ""] {
+        let defective = base.replace("{IGNORE}", ignore).replace("{N}", "0");
+        let Err(err) = Simulation::open(&defective) else {
+            panic!("defects are heard, ignored or served");
+        };
+        assert!(err.to_string().contains("Manning"), "{err}");
+    }
 }

--- a/crates/engine-uds/tests/session.rs
+++ b/crates/engine-uds/tests/session.rs
@@ -6548,6 +6548,60 @@ fn the_highest_continuity_errors_list_skips_terminal_and_quiet_vertices() {
     assert!(listed.len() <= 5, "more than five listed: {listed:?}");
 }
 
+/// §14.15: an external mesh file's sections continue the model's own —
+/// indices, units header and all — and a declared-but-unsupplied file
+/// is a named refusal, or a named warning under IGNORE_2D.
+#[test]
+fn an_external_mesh_file_continues_the_inline_sections() {
+    let model = "[OPTIONS]
+FLOW_UNITS CMS
+END_TIME 00:10:00
+        [JUNCTIONS]
+J1 10 4 0 0 0
+[OUTFALLS]
+O1 9 FREE NO
+        [CONDUITS]
+C1 J1 O1 100 0.013 0 0 0 0
+        [XSECTIONS]
+C1 CIRCULAR 1 0 0 0 1
+        [2D_MESH_FILE]
+FILE terrain.2dm
+        [2D_VERTEX_NODE_MAP]
+VA J1
+";
+    let external = ";; UNITS: SI (m)
+[2D_VERTICES]
+0 0 10
+1 0 10 VA
+0 1 10
+        [2D_TRIANGLES]
+0 1 2 0.02
+";
+
+    // Supplied: the coupling row in the model resolves against a vertex
+    // the external file authors, and the refusal is the not-served one.
+    let Err(err) = Simulation::open_with_overland_mesh(model, external) else {
+        panic!("mesh models refuse until served");
+    };
+    assert!(err.to_string().contains("IGNORE_2D"), "{err}");
+
+    // Not supplied: the refusal names the file instead.
+    let Err(err) = Simulation::open(model) else {
+        panic!("missing mesh file refuses");
+    };
+    assert!(err.to_string().contains("terrain.2dm"), "{err}");
+
+    // Ignored and not supplied: the 1D half runs, warned.
+    let ignored = model.replace(
+        "FLOW_UNITS CMS",
+        "FLOW_UNITS CMS
+IGNORE_2D YES",
+    );
+    let (mut sim, diags, _) = Simulation::open(&ignored).expect("1D half runs");
+    assert!(diags.iter().any(|d| d.to_string().contains("terrain.2dm")));
+    sim.run();
+}
+
 /// §1.8: a mesh model refuses with the campaign named; `IGNORE_2D YES`
 /// runs its one-dimensional half; and an ignored mesh is still
 /// validated, so an authoring defect is heard now rather than on the

--- a/crates/engine-uds/tests/session.rs
+++ b/crates/engine-uds/tests/session.rs
@@ -6547,3 +6547,40 @@ fn the_highest_continuity_errors_list_skips_terminal_and_quiet_vertices() {
     }
     assert!(listed.len() <= 5, "more than five listed: {listed:?}");
 }
+
+/// §1.8: a mesh model refuses with the campaign named; `IGNORE_2D YES`
+/// runs its one-dimensional half; and an ignored mesh is still
+/// validated, so an authoring defect is heard now rather than on the
+/// day the option flips off.
+#[test]
+fn a_mesh_model_refuses_until_overland_is_served() {
+    let base = "[OPTIONS]\nFLOW_UNITS CMS\nROUTING_STEP 5\n\
+        END_TIME 00:10:00\n{IGNORE}\n\
+        [JUNCTIONS]\nJ1 10 4 0 0 0\n[OUTFALLS]\nO1 9 FREE NO\n\
+        [CONDUITS]\nC1 J1 O1 100 0.013 0 0 0 0\n\
+        [XSECTIONS]\nC1 CIRCULAR 1 0 0 0 1\n\
+        [2D_VERTICES]\n0 0 10\n1 0 10\n0 1 10\n\
+        [2D_TRIANGLES]\n0 1 2 {N}\n";
+
+    let refused = base.replace("{IGNORE}", "").replace("{N}", "0.02");
+    let Err(err) = Simulation::open(&refused) else {
+        panic!("mesh models refuse");
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("IGNORE_2D"), "{msg}");
+
+    let ignored = base
+        .replace("{IGNORE}", "IGNORE_2D YES")
+        .replace("{N}", "0.02");
+    let (mut sim, diags, _) = Simulation::open(&ignored).expect("1D half runs");
+    assert!(diags.iter().all(|d| !d.kind.is_error()));
+    sim.run();
+
+    let defective = base
+        .replace("{IGNORE}", "IGNORE_2D YES")
+        .replace("{N}", "0");
+    let Err(err) = Simulation::open(&defective) else {
+        panic!("defects are heard even ignored");
+    };
+    assert!(err.to_string().contains("Manning"), "{err}");
+}

--- a/crates/engines/src/session.rs
+++ b/crates/engines/src/session.rs
@@ -347,6 +347,15 @@ impl EngineSession {
         }
     }
 
+    /// The uds session, mutably — attaching the §14.16 overland
+    /// results stream is the capability that needs it.
+    pub fn as_uds_mut(&mut self) -> Option<&mut hydra_engine_uds::simulation::Simulation> {
+        match self {
+            Self::Wds(_) => None,
+            Self::Uds(r) => Some(&mut r.0.sim),
+        }
+    }
+
     /// Whether this engine can checkpoint a run at all.
     ///
     /// Asked before offering the operation rather than discovering it from

--- a/crates/gui/src/commands/uds_create.rs
+++ b/crates/gui/src/commands/uds_create.rs
@@ -622,6 +622,7 @@ pub(crate) fn create_uds_gage(net: &mut Network, id: &str, series_id: &str) -> R
         .position(|t| t.id.eq_ignore_ascii_case(series_id))
         .ok_or_else(|| format!("'{series_id}' is not a time series in this model"))?;
     net.gages.push(hydra::uds::model::Gage {
+        position: None,
         id: id.to_string(),
         // Intensity at an hourly interval, which is how a rainfall
         // record is most often written and what the series it reads

--- a/scripts/tests/test_spec_language.py
+++ b/scripts/tests/test_spec_language.py
@@ -71,7 +71,7 @@ class SpecLanguageTests(unittest.TestCase):
 
     def test_the_scan_reads_every_spec(self):
         found = {p.relative_to(ROOT).as_posix() for p in specs()}
-        self.assertEqual(15, len(found), sorted(found))
+        self.assertEqual(16, len(found), sorted(found))
         for expected in (
             "crates/common/src/spec.md",
             "crates/engine-uds/src/hydraulics/spec.md",


### PR DESCRIPTION
Serves §15: two-dimensional overland flow as functionality of the uds engine, spec-first end to end, on the SWMM input format's 2D sections.

## What this adds

**Specification.** A full solver spec (`overland/spec.md` §15: mesh, stage–storage closures, local-inertial marcher, boundaries, network coupling, meteorology, conservation, verification) written from a study of SWMM6's 2D implementation, with correspondence notes and measured predecessor lessons recorded where the two engines deliberately differ. Interop grammar in §14.15, and §14.16 for the results stream.

**The marcher.** An explicit local-inertial finite-volume scheme (de Almeida & Bates θ-blend) on unstructured triangles, all f64: FLAT and VFR stage–storage closures, MEAN and VFR_FACE face depths, Perot velocity reconstruction, wetting/drying with hysteresis and a one-ring halo, and power-of-two local time stepping with exact tier-interface accounting. Conservation is structural: a closed basin holds to 1e-10 through wetting, drying, positivity capping and boundary clamping.

**Coupling.** The C¹-regularised orifice exchange with rim gate, area ramp and wetting ramps; drains β-capped per substep, spills drawn against a per-advance node ledger. Coupled vertices pond over their mesh footprint and take the exchange conductance as §6.4 damping; coupled outfalls blend toward the surface tailwater inside every iteration. The surface co-advances per routing period with COUPLING_SYNC batching, exchange delivered as next-period laterals.

**Results and reporting.** A Hydra-native framed sidecar (§14.16) at the reporting instants — geometry in the header, per-cell depth/surface/velocity and the §15.8 ledger per record — plus the overland continuity balance, time-step summary, and the flow balance's surface drainage/spill pair in the run summary.

**Checkpointing.** Mesh runs checkpoint and resume bit-identically (format v4) behind their own mesh fingerprint.

## Verification

Every §15.9 family is gated in-repo: analytic (lake-at-rest exact, SWASHES subcritical bump 0.92% rel L1, MacDonald 1000 m subcritical 2.15% beside the predecessor's own 2.0%), conservation (1e-10 with LTS-vs-global equivalence), determinism (byte-identical at every worker width, SI/US authorings agree). The supercritical MacDonald profile is a recorded expected failure, as in the predecessor's validation table.

## Performance

On an identical 120k-cell dam-break model, 2.7x faster than SWMM6's own 2D solver serial (5.8 s vs 15.9 s) and 3.1x at four threads (3.0 s vs 9.3 s), via per-tier firing lists and active-only marching with lazy source integration.

## Breaking

Mesh models that previously refused with "specified and not yet served" now open and run; `OpenError::Overland` carries attach defects instead of the serving refusal. `IGNORE_2D YES` still runs the one-dimensional model alone. Checkpoint format v3 files are refused by the version gate, as always.

## Recorded deferrals (§15.10)

Sub-rim street drainage, runoff-to-mesh, mesh infiltration, overland constituent transport, mesh adaptivity — each a typed absence, not an approximation. GUI surface rendering is the natural next campaign alongside inlet coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)